### PR TITLE
"HTTP Error 422: Unprocessable Entity" fixed

### DIFF
--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -275,7 +275,7 @@ class Tado:
         if duration is not None:
             post_data["termination"]["durationInSeconds"] = duration
 
-        data = self._apiCall(cmd, "PUT", post_data, True)
+        data = self._apiCall(cmd, "PUT", post_data)
         return data
 
     # Ctor


### PR DESCRIPTION
The PUT API call for overlays requires a proper content-type now.
The DELETE overlay call must be still plain.

Fixes https://github.com/home-assistant/home-assistant/issues/13548
