### PR TITLE
add getHomeState(), setAway() and setHome()

### DIFF
--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -204,6 +204,17 @@ class Tado:
         data = self._apiCall(cmd)
         return data
 
+    def getHomeState(self):
+        """Gets current state of Home."""
+        # returns {"presence":"AWAY"} or {"presence":"HOME"}
+        # without an auto assist skill presence is not switched automatically,
+        # but a button is shown in the app. showHomePresenceSwitchButton
+        # is an indicator, that the homeState can be switched
+        # {"presence":"HOME","showHomePresenceSwitchButton":true}
+        cmd = 'state'
+        data = self._apiCall(cmd)
+        return data
+    
     def getCapabilities(self, zone):
         """Gets current capabilities of Zone zone."""
         # pylint: disable=C0103
@@ -355,6 +366,23 @@ class Tado:
         data = self._apiCall(cmd, "PUT", post_data)
         return data
 
+    def setHome(self):
+        """Sets HomeState to HOME """
+        # it seems, this can be set anytime
+        cmd = 'presence'
+        payload = '{"homePresence":"HOME"}'
+        data = self._apiCallPayload(cmd, "PUT", payload)
+        return data
+
+    def setAway(self):
+        """Sets HomeState to AWAY """
+        # this can only be set if everybody left the home and 
+        # showHomePresenceSwitchButton = true
+        cmd = 'presence'
+        payload = '{"homePresence":"AWAY"}'
+        data = self._apiCallPayload(cmd, "PUT", payload)
+        return data
+    
     # Ctor
     def __init__(self, username, password):
         """Performs login and save session cookie."""

--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -371,7 +371,7 @@ class Tado:
         # it seems, this can be set anytime
         cmd = 'presence'
         payload = '{"homePresence":"HOME"}'
-        data = self._apiCallPayload(cmd, "PUT", payload)
+        data = self._apiCall(cmd, "PUT", payload)
         return data
 
     def setAway(self):
@@ -380,7 +380,7 @@ class Tado:
         # showHomePresenceSwitchButton = true
         cmd = 'presence'
         payload = '{"homePresence":"AWAY"}'
-        data = self._apiCallPayload(cmd, "PUT", payload)
+        data = self._apiCall(cmd, "PUT", payload)
         return data
     
     # Ctor


### PR DESCRIPTION
i got this up and running with an older version of pyTado, but this should work, though i didn’t test it. 
to integrate this in homeassistant i made a sensor from the getHomeState() return value and derived a binary sensor from the showHomePresenceSwitchButton attribute.
as soon as showHomePresenceSwitchButton is not none anymore an automation toogles the home state. this mimics the auto assist skill pretty well.
also: i don’t know if or how any of this works if the auto assist skill is active.