### PR TITLE
Fix setHome/setAway incorrectly using a string literal

### DIFF
--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -381,7 +381,7 @@ class Tado:
         """Sets HomeState to HOME """
         # it seems, this can be set anytime
         cmd = 'presence'
-        payload = '{"homePresence":"HOME"}'
+        payload = { "homePresence": "HOME" }
         data = self._apiCall(cmd, "PUT", payload)
         return data
 
@@ -390,7 +390,7 @@ class Tado:
         # this can only be set if everybody left the home and 
         # showHomePresenceSwitchButton = true
         cmd = 'presence'
-        payload = '{"homePresence":"AWAY"}'
+        payload = { "homePresence": "AWAY" }
         data = self._apiCall(cmd, "PUT", payload)
         return data
     


### PR DESCRIPTION
This was leading to HTTP 422 error responses from the API due to a malformed payload as the JSON was being double encoded in `_apicall()`.

HTTP 422 responses appear to still be delivered delivered if the app would not support switching to home or away in the current state, both otherwise work when expected with this change.