### PR TITLE
Possibility to connect to different tado accounts

### DIFF
--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -31,11 +31,8 @@ class Tado:
     _debugCalls = False
 
     # Instance-wide constant info
-    headers = {'Referer' : 'https://my.tado.com/'}
     api2url = 'https://my.tado.com/api/v2/homes/'
     mobi2url = 'https://my.tado.com/mobile/1.9/'
-    refresh_token = ''
-    refresh_at = datetime.datetime.now() + datetime.timedelta(minutes=5)
     timeout = 10
 
     # 'Private' methods for use in class, Tado mobile API V1.9.
@@ -432,6 +429,9 @@ class Tado:
     def __init__(self, username, password):
         """Performs login and save session cookie."""
         # HTTPS Interface
+        self.headers = {'Referer' : 'https://my.tado.com/'}
+        self.refresh_token = ''
+        self.refresh_at = datetime.datetime.now() + datetime.timedelta(minutes=5)
 
         # pylint: disable=C0103
         cj = CookieJar()


### PR DESCRIPTION
Earlier access token was saved into class variable, and that lead to inconsistency between device id in url and access token.