### PR TITLE
Convert to using requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-
+requests

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open(here('README.md')).read()
 requirements = [x.strip() for x in open(here('requirements.txt')).readlines()]
 
 setup(name='python-tado',
-      version='0.3.1',
+      version='0.4.0',
       description='PyTado from chrism0dwk, modfied by w.malgadey, diplix, michaelarnauts, LenhartStephan, splifter, syssi, andersonshatch, Yippy, p0thi',
       long_description=readme,
       keywords='tado',


### PR DESCRIPTION
Add support for passing in a requests Session

A single session is used for the length
of the object which avoids the ssl startup
overhead for each request.