### PR TITLE
Add a TadoZone class and tests for known Tados

### DIFF
--- a/PyTado/const.py
+++ b/PyTado/const.py
@@ -1,0 +1,69 @@
+"""Constant values for the Tado component."""
+
+# Types
+TYPE_AIR_CONDITIONING = "AIR_CONDITIONING"
+TYPE_HEATING = "HEATING"
+TYPE_HOT_WATER = "HOT_WATER"
+
+# Base modes
+CONST_MODE_OFF = "OFF"
+CONST_MODE_SMART_SCHEDULE = "SMART_SCHEDULE"  # Use the schedule
+CONST_MODE_AUTO = "AUTO"
+CONST_MODE_COOL = "COOL"
+CONST_MODE_HEAT = "HEAT"
+CONST_MODE_DRY = "DRY"
+CONST_MODE_FAN = "FAN"
+
+CONST_LINK_OFFLINE = "OFFLINE"
+
+CONST_FAN_OFF = "OFF"
+CONST_FAN_AUTO = "AUTO"
+CONST_FAN_LOW = "LOW"
+CONST_FAN_MIDDLE = "MIDDLE"
+CONST_FAN_HIGH = "HIGH"
+
+# When we change the temperature setting, we need an overlay mode
+CONST_OVERLAY_TADO_MODE = "TADO_MODE"  # wait until tado changes the mode automatic
+CONST_OVERLAY_MANUAL = "MANUAL"  # the user has change the temperature or mode manually
+CONST_OVERLAY_TIMER = "TIMER"  # the temperature will be reset after a timespan
+
+# Heat always comes first since we get the
+# min and max tempatures for the zone from
+# it.
+# Heat is preferred as it generally has a lower minimum temperature
+ORDERED_KNOWN_TADO_MODES = [
+    CONST_MODE_HEAT,
+    CONST_MODE_COOL,
+    CONST_MODE_AUTO,
+    CONST_MODE_DRY,
+    CONST_MODE_FAN,
+]
+
+CONST_HVAC_HEAT = "HEATING"
+CONST_HVAC_DRY = "DRYING"
+CONST_HVAC_FAN = "FAN"
+CONST_HVAC_COOL = "COOLING"
+CONST_HVAC_IDLE = "IDLE"
+CONST_HVAC_OFF = "OFF"
+CONST_HVAC_HOT_WATER = TYPE_HOT_WATER
+
+TADO_MODES_TO_HVAC_ACTION = {
+    CONST_MODE_HEAT: CONST_HVAC_HEAT,
+    CONST_MODE_DRY: CONST_HVAC_DRY,
+    CONST_MODE_FAN: CONST_HVAC_FAN,
+    CONST_MODE_COOL: CONST_HVAC_COOL,
+}
+
+TADO_HVAC_ACTION_TO_MODES = {
+    CONST_HVAC_HEAT: CONST_MODE_HEAT,
+    CONST_HVAC_HOT_WATER: CONST_HVAC_HEAT,
+    CONST_HVAC_DRY: CONST_MODE_DRY,
+    CONST_HVAC_FAN: CONST_MODE_FAN,
+    CONST_HVAC_COOL: CONST_MODE_COOL,
+}
+
+
+# These modes will not allow a temp to be set
+TADO_MODES_WITH_NO_TEMP_SETTING = [CONST_MODE_AUTO, CONST_MODE_DRY, CONST_MODE_FAN]
+
+DEFAULT_TADO_PRECISION = 0.1

--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -10,6 +10,7 @@ from requests import Session
 
 from enum import IntEnum
 
+from .zone import TadoZone
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -172,6 +173,10 @@ class Tado:
         cmd = 'zones'
         data = self._apiCall(cmd)
         return data
+
+    def getZoneState(self, zone):
+        """Gets current state of Zone as a TadoZone object."""
+        return TadoZone(self.getState(zone), zone)
 
     def getState(self, zone):
         """Gets current state of Zone zone."""

--- a/PyTado/zone.py
+++ b/PyTado/zone.py
@@ -1,0 +1,300 @@
+"""Adapter to represent a tado zones and state."""
+import logging
+
+from .const import (
+    CONST_FAN_AUTO,
+    CONST_FAN_OFF,
+    CONST_HVAC_COOL,
+    CONST_HVAC_HEAT,
+    CONST_HVAC_IDLE,
+    CONST_HVAC_OFF,
+    CONST_LINK_OFFLINE,
+    CONST_MODE_OFF,
+    CONST_MODE_SMART_SCHEDULE,
+    DEFAULT_TADO_PRECISION,
+    TADO_HVAC_ACTION_TO_MODES,
+    TADO_MODES_TO_HVAC_ACTION,
+    TYPE_AIR_CONDITIONING,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TadoZone:
+    """Represent a tado zone."""
+
+    def __init__(self, data, zone_id):
+        """Create a tado zone."""
+        self._data = data
+        self._zone_id = zone_id
+        self._current_temp = None
+        self._connection = None
+        self._current_temp_timestamp = None
+        self._current_humidity = None
+        self._current_humidity_timestamp = None
+        self._is_away = False
+        self._current_hvac_action = None
+        self._current_fan_speed = None
+        self._current_hvac_mode = None
+        self._target_temp = None
+        self._available = False
+        self._power = None
+        self._link = None
+        self._ac_power_timestamp = None
+        self._heating_power_timestamp = None
+        self._ac_power = None
+        self._heating_power = None
+        self._heating_power_percentage = None
+        self._tado_mode = None
+        self._overlay_active = None
+        self._overlay_termination_type = None
+        self._preparation = None
+        self._open_window = None
+        self._open_window_attr = None
+        self._precision = DEFAULT_TADO_PRECISION
+        self.update_data(data)
+
+    @property
+    def preparation(self):
+        """Zone is preparing to heat."""
+        return self._preparation
+
+    @property
+    def open_window(self):
+        """Window is open."""
+        return self._open_window
+
+    @property
+    def open_window_attr(self):
+        """Window open attributes."""
+        return self._open_window_attr
+
+    @property
+    def current_temp(self):
+        """Temperature of the zone."""
+        return self._current_temp
+
+    @property
+    def current_temp_timestamp(self):
+        """Temperature of the zone timestamp."""
+        return self._current_temp_timestamp
+
+    @property
+    def connection(self):
+        """Up or down internet connection."""
+        return self._connection
+
+    @property
+    def tado_mode(self):
+        """Tado mode."""
+        return self._tado_mode
+
+    @property
+    def overlay_active(self):
+        """Overlay acitive."""
+        return self._current_hvac_mode != CONST_MODE_SMART_SCHEDULE
+
+    @property
+    def overlay_termination_type(self):
+        """Overlay termination type (what happens when period ends)."""
+        return self._overlay_termination_type
+
+    @property
+    def current_humidity(self):
+        """Humidity of the zone."""
+        return self._current_humidity
+
+    @property
+    def current_humidity_timestamp(self):
+        """Humidity of the zone timestamp."""
+        return self._current_humidity_timestamp
+
+    @property
+    def ac_power_timestamp(self):
+        """AC power timestamp."""
+        return self._ac_power_timestamp
+
+    @property
+    def heating_power_timestamp(self):
+        """Heating power timestamp."""
+        return self._heating_power_timestamp
+
+    @property
+    def ac_power(self):
+        """AC power."""
+        return self._ac_power
+
+    @property
+    def heating_power(self):
+        """Heating power."""
+        return self._heating_power
+
+    @property
+    def heating_power_percentage(self):
+        """Heating power percentage."""
+        return self._heating_power_percentage
+
+    @property
+    def is_away(self):
+        """Is Away (not home)."""
+        return self._is_away
+
+    @property
+    def power(self):
+        """Power is on."""
+        return self._power
+
+    @property
+    def current_hvac_action(self):
+        """HVAC Action (home assistant const)."""
+        return self._current_hvac_action
+
+    @property
+    def current_fan_speed(self):
+        """TADO Fan speed (tado const)."""
+        return self._current_fan_speed
+
+    @property
+    def link(self):
+        """Link (internet connection state)."""
+        return self._link
+
+    @property
+    def precision(self):
+        """Precision of temp units."""
+        return self._precision
+
+    @property
+    def current_hvac_mode(self):
+        """TADO HVAC Mode (tado const)."""
+        return self._current_hvac_mode
+
+    @property
+    def target_temp(self):
+        """Target temperature (C)."""
+        return self._target_temp
+
+    @property
+    def available(self):
+        """Device is available and link is up."""
+        return self._available
+
+    def update_data(self, data):
+        """Handle update callbacks."""
+        _LOGGER.debug("Processing data from zone %d", self._zone_id)
+        if "sensorDataPoints" in data:
+            sensor_data = data["sensorDataPoints"]
+
+            if "insideTemperature" in sensor_data:
+                temperature = float(sensor_data["insideTemperature"]["celsius"])
+                self._current_temp = temperature
+                self._current_temp_timestamp = sensor_data["insideTemperature"][
+                    "timestamp"
+                ]
+                if "precision" in sensor_data["insideTemperature"]:
+                    self._precision = sensor_data["insideTemperature"]["precision"][
+                        "celsius"
+                    ]
+
+            if "humidity" in sensor_data:
+                humidity = float(sensor_data["humidity"]["percentage"])
+                self._current_humidity = humidity
+                self._current_humidity_timestamp = sensor_data["humidity"]["timestamp"]
+
+        self._is_away = None
+        self._tado_mode = None
+        if "tadoMode" in data:
+            self._is_away = data["tadoMode"] == "AWAY"
+            self._tado_mode = data["tadoMode"]
+
+        self._link = None
+        if "link" in data:
+            self._link = data["link"]["state"]
+
+        self._current_hvac_action = CONST_HVAC_OFF
+
+        if "setting" in data:
+            # temperature setting will not exist when device is off
+            if (
+                "temperature" in data["setting"]
+                and data["setting"]["temperature"] is not None
+            ):
+                setting = float(data["setting"]["temperature"]["celsius"])
+                self._target_temp = setting
+
+            setting = data["setting"]
+
+            self._current_fan_speed = None
+            # If there is no overlay, the mode will always be
+            # "SMART_SCHEDULE"
+            self._current_hvac_mode = CONST_MODE_OFF
+            if "mode" in setting:
+                # v3 devices use mode
+                self._current_hvac_mode = setting["mode"]
+
+            self._power = setting["power"]
+            if self._power == "ON":
+                self._current_hvac_action = CONST_HVAC_IDLE
+                if (
+                    "mode" not in setting
+                    and "type" in setting
+                    and setting["type"] in TADO_HVAC_ACTION_TO_MODES
+                ):
+                    # v2 devices do not have mode so we have to figure it out from type
+                    self._current_hvac_mode = TADO_HVAC_ACTION_TO_MODES[setting["type"]]
+
+            # Not all devices have fans
+            if "fanSpeed" in setting:
+                self._current_fan_speed = setting.get(
+                    "fanSpeed", CONST_FAN_AUTO if self._power == "ON" else CONST_FAN_OFF
+                )
+            elif "type" in setting and setting["type"] == TYPE_AIR_CONDITIONING:
+                self._current_fan_speed = (
+                    CONST_FAN_AUTO if self._power == "ON" else CONST_FAN_OFF
+                )
+
+        self._preparation = "preparation" in data and data["preparation"] is not None
+        self._open_window = "openWindow" in data and data["openWindow"] is not None
+        self._open_window_attr = data["openWindow"] if self._open_window else {}
+
+        if "activityDataPoints" in data:
+            activity_data = data["activityDataPoints"]
+            if "acPower" in activity_data and activity_data["acPower"] is not None:
+                self._ac_power = activity_data["acPower"]["value"]
+                self._ac_power_timestamp = activity_data["acPower"]["timestamp"]
+                if activity_data["acPower"]["value"] == "ON" and self._power == "ON":
+                    # acPower means the unit has power so we need to map the mode
+                    self._current_hvac_action = TADO_MODES_TO_HVAC_ACTION.get(
+                        self._current_hvac_mode, CONST_HVAC_COOL
+                    )
+            if (
+                "heatingPower" in activity_data
+                and activity_data["heatingPower"] is not None
+            ):
+                self._heating_power = activity_data["heatingPower"].get("value", None)
+                self._heating_power_timestamp = activity_data["heatingPower"][
+                    "timestamp"
+                ]
+                self._heating_power_percentage = float(
+                    activity_data["heatingPower"].get("percentage", 0)
+                )
+
+                if self._heating_power_percentage > 0.0 and self._power == "ON":
+                    self._current_hvac_action = CONST_HVAC_HEAT
+
+        # If there is no overlay
+        # then we are running the smart schedule
+        self._overlay_termination_type = None
+        if "overlay" in data and data["overlay"] is not None:
+            if (
+                "termination" in data["overlay"]
+                and "type" in data["overlay"]["termination"]
+            ):
+                self._overlay_termination_type = data["overlay"]["termination"]["type"]
+        else:
+            self._current_hvac_mode = CONST_MODE_SMART_SCHEDULE
+
+        self._connection = (
+            data["connectionState"]["value"] if "connectionState" in data else None
+        )
+        self._available = self._link != CONST_LINK_OFFLINE

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open(here('README.md')).read()
 requirements = [x.strip() for x in open(here('requirements.txt')).readlines()]
 
 setup(name='python-tado',
-      version='0.4.0',
+      version='0.5.0',
       description='PyTado from chrism0dwk, modfied by w.malgadey, diplix, michaelarnauts, LenhartStephan, splifter, syssi, andersonshatch, Yippy, p0thi',
       long_description=readme,
       keywords='tado',

--- a/tests/fixtures/ac_issue_32294.heat_mode.json
+++ b/tests/fixtures/ac_issue_32294.heat_mode.json
@@ -1,0 +1,60 @@
+{
+	"tadoMode": "HOME",
+	"sensorDataPoints": {
+		"insideTemperature": {
+			"fahrenheit": 71.28,
+			"timestamp": "2020-02-29T22:51:05.016Z",
+			"celsius": 21.82,
+			"type": "TEMPERATURE",
+			"precision": {
+				"fahrenheit": 0.1,
+				"celsius": 0.1
+			}
+		},
+		"humidity": {
+			"timestamp": "2020-02-29T22:51:05.016Z",
+			"percentage": 40.4,
+			"type": "PERCENTAGE"
+		}
+	},
+	"link": {
+		"state": "ONLINE"
+	},
+	"openWindow": null,
+	"geolocationOverride": false,
+	"geolocationOverrideDisableTime": null,
+	"overlay": null,
+	"activityDataPoints": {
+		"acPower": {
+			"timestamp": "2020-02-29T22:50:34.850Z",
+			"type": "POWER",
+			"value": "ON"
+		}
+	},
+	"nextTimeBlock": {
+		"start": "2020-03-01T00:00:00.000Z"
+	},
+	"preparation": null,
+	"overlayType": null,
+	"nextScheduleChange": {
+		"start": "2020-03-01T00:00:00Z",
+		"setting": {
+			"type": "AIR_CONDITIONING",
+			"mode": "HEAT",
+			"power": "ON",
+			"temperature": {
+				"fahrenheit": 59.0,
+				"celsius": 15.0
+			}
+		}
+	},
+	"setting": {
+		"type": "AIR_CONDITIONING",
+		"mode": "HEAT",
+		"power": "ON",
+		"temperature": {
+			"fahrenheit": 77.0,
+			"celsius": 25.0
+		}
+	}
+}

--- a/tests/fixtures/hvac_action_heat.json
+++ b/tests/fixtures/hvac_action_heat.json
@@ -1,0 +1,67 @@
+{
+    "tadoMode": "HOME",
+    "geolocationOverride": false,
+    "geolocationOverrideDisableTime": null,
+    "preparation": null,
+    "setting": {
+        "type": "AIR_CONDITIONING",
+        "power": "ON",
+        "mode": "HEAT",
+        "temperature": {
+            "celsius": 16.11,
+            "fahrenheit": 61.00
+        },
+        "fanSpeed": "AUTO"
+    },
+    "overlayType": "MANUAL",
+    "overlay": {
+        "type": "MANUAL",
+        "setting": {
+            "type": "AIR_CONDITIONING",
+            "power": "ON",
+            "mode": "HEAT",
+            "temperature": {
+                "celsius": 16.11,
+                "fahrenheit": 61.00
+            },
+            "fanSpeed": "AUTO"
+        },
+        "termination": {
+            "type": "TADO_MODE",
+            "typeSkillBasedApp": "TADO_MODE",
+            "projectedExpiry": null
+        }
+    },
+    "openWindow": null,
+    "nextScheduleChange": null,
+    "nextTimeBlock": {
+        "start": "2020-03-07T04:00:00.000Z"
+    },
+    "link": {
+        "state": "ONLINE"
+    },
+    "activityDataPoints": {
+        "acPower": {
+            "timestamp": "2020-03-06T17:38:30.302Z",
+            "type": "POWER",
+            "value": "OFF"
+        }
+    },
+    "sensorDataPoints": {
+        "insideTemperature": {
+            "celsius": 21.40,
+            "fahrenheit": 70.52,
+            "timestamp": "2020-03-06T18:06:09.546Z",
+            "type": "TEMPERATURE",
+            "precision": {
+                "celsius": 0.1,
+                "fahrenheit": 0.1
+            }
+        },
+        "humidity": {
+            "type": "PERCENTAGE",
+            "percentage": 50.40,
+            "timestamp": "2020-03-06T18:06:09.546Z"
+        }
+    }
+}

--- a/tests/fixtures/smartac3.auto_mode.json
+++ b/tests/fixtures/smartac3.auto_mode.json
@@ -1,0 +1,57 @@
+{
+	"tadoMode": "HOME",
+	"sensorDataPoints": {
+		"insideTemperature": {
+			"fahrenheit": 76.64,
+			"timestamp": "2020-03-05T03:55:38.160Z",
+			"celsius": 24.8,
+			"type": "TEMPERATURE",
+			"precision": {
+				"fahrenheit": 0.1,
+				"celsius": 0.1
+			}
+		},
+		"humidity": {
+			"timestamp": "2020-03-05T03:55:38.160Z",
+			"percentage": 62.5,
+			"type": "PERCENTAGE"
+		}
+	},
+	"link": {
+		"state": "ONLINE"
+	},
+	"openWindow": null,
+	"geolocationOverride": false,
+	"geolocationOverrideDisableTime": null,
+	"overlay": {
+		"termination": {
+			"typeSkillBasedApp": "TADO_MODE",
+			"projectedExpiry": null,
+			"type": "TADO_MODE"
+		},
+		"setting": {
+			"type": "AIR_CONDITIONING",
+			"mode": "AUTO",
+			"power": "ON"
+		},
+		"type": "MANUAL"
+	},
+	"activityDataPoints": {
+		"acPower": {
+			"timestamp": "2020-03-05T03:56:38.627Z",
+			"type": "POWER",
+			"value": "ON"
+		}
+	},
+	"nextTimeBlock": {
+		"start": "2020-03-05T08:00:00.000Z"
+	},
+	"preparation": null,
+	"overlayType": "MANUAL",
+	"nextScheduleChange": null,
+	"setting": {
+		"type": "AIR_CONDITIONING",
+		"mode": "AUTO",
+		"power": "ON"
+	}
+}

--- a/tests/fixtures/smartac3.cool_mode.json
+++ b/tests/fixtures/smartac3.cool_mode.json
@@ -1,0 +1,67 @@
+{
+	"tadoMode": "HOME",
+	"sensorDataPoints": {
+		"insideTemperature": {
+			"fahrenheit": 76.57,
+			"timestamp": "2020-03-05T03:57:38.850Z",
+			"celsius": 24.76,
+			"type": "TEMPERATURE",
+			"precision": {
+				"fahrenheit": 0.1,
+				"celsius": 0.1
+			}
+		},
+		"humidity": {
+			"timestamp": "2020-03-05T03:57:38.850Z",
+			"percentage": 60.9,
+			"type": "PERCENTAGE"
+		}
+	},
+	"link": {
+		"state": "ONLINE"
+	},
+	"openWindow": null,
+	"geolocationOverride": false,
+	"geolocationOverrideDisableTime": null,
+	"overlay": {
+		"termination": {
+			"typeSkillBasedApp": "TADO_MODE",
+			"projectedExpiry": null,
+			"type": "TADO_MODE"
+		},
+		"setting": {
+			"fanSpeed": "AUTO",
+			"type": "AIR_CONDITIONING",
+			"mode": "COOL",
+			"power": "ON",
+			"temperature": {
+				"fahrenheit": 64.0,
+				"celsius": 17.78
+			}
+		},
+		"type": "MANUAL"
+	},
+	"activityDataPoints": {
+		"acPower": {
+			"timestamp": "2020-03-05T04:01:07.162Z",
+			"type": "POWER",
+			"value": "ON"
+		}
+	},
+	"nextTimeBlock": {
+		"start": "2020-03-05T08:00:00.000Z"
+	},
+	"preparation": null,
+	"overlayType": "MANUAL",
+	"nextScheduleChange": null,
+	"setting": {
+		"fanSpeed": "AUTO",
+		"type": "AIR_CONDITIONING",
+		"mode": "COOL",
+		"power": "ON",
+		"temperature": {
+			"fahrenheit": 64.0,
+			"celsius": 17.78
+		}
+	}
+}

--- a/tests/fixtures/smartac3.dry_mode.json
+++ b/tests/fixtures/smartac3.dry_mode.json
@@ -1,0 +1,57 @@
+{
+	"tadoMode": "HOME",
+	"sensorDataPoints": {
+		"insideTemperature": {
+			"fahrenheit": 77.02,
+			"timestamp": "2020-03-05T04:02:07.396Z",
+			"celsius": 25.01,
+			"type": "TEMPERATURE",
+			"precision": {
+				"fahrenheit": 0.1,
+				"celsius": 0.1
+			}
+		},
+		"humidity": {
+			"timestamp": "2020-03-05T04:02:07.396Z",
+			"percentage": 62.0,
+			"type": "PERCENTAGE"
+		}
+	},
+	"link": {
+		"state": "ONLINE"
+	},
+	"openWindow": null,
+	"geolocationOverride": false,
+	"geolocationOverrideDisableTime": null,
+	"overlay": {
+		"termination": {
+			"typeSkillBasedApp": "TADO_MODE",
+			"projectedExpiry": null,
+			"type": "TADO_MODE"
+		},
+		"setting": {
+			"type": "AIR_CONDITIONING",
+			"mode": "DRY",
+			"power": "ON"
+		},
+		"type": "MANUAL"
+	},
+	"activityDataPoints": {
+		"acPower": {
+			"timestamp": "2020-03-05T04:02:40.867Z",
+			"type": "POWER",
+			"value": "ON"
+		}
+	},
+	"nextTimeBlock": {
+		"start": "2020-03-05T08:00:00.000Z"
+	},
+	"preparation": null,
+	"overlayType": "MANUAL",
+	"nextScheduleChange": null,
+	"setting": {
+		"type": "AIR_CONDITIONING",
+		"mode": "DRY",
+		"power": "ON"
+	}
+}

--- a/tests/fixtures/smartac3.fan_mode.json
+++ b/tests/fixtures/smartac3.fan_mode.json
@@ -1,0 +1,57 @@
+{
+	"tadoMode": "HOME",
+	"sensorDataPoints": {
+		"insideTemperature": {
+			"fahrenheit": 77.02,
+			"timestamp": "2020-03-05T04:02:07.396Z",
+			"celsius": 25.01,
+			"type": "TEMPERATURE",
+			"precision": {
+				"fahrenheit": 0.1,
+				"celsius": 0.1
+			}
+		},
+		"humidity": {
+			"timestamp": "2020-03-05T04:02:07.396Z",
+			"percentage": 62.0,
+			"type": "PERCENTAGE"
+		}
+	},
+	"link": {
+		"state": "ONLINE"
+	},
+	"openWindow": null,
+	"geolocationOverride": false,
+	"geolocationOverrideDisableTime": null,
+	"overlay": {
+		"termination": {
+			"typeSkillBasedApp": "TADO_MODE",
+			"projectedExpiry": null,
+			"type": "TADO_MODE"
+		},
+		"setting": {
+			"type": "AIR_CONDITIONING",
+			"mode": "FAN",
+			"power": "ON"
+		},
+		"type": "MANUAL"
+	},
+	"activityDataPoints": {
+		"acPower": {
+			"timestamp": "2020-03-05T04:03:44.328Z",
+			"type": "POWER",
+			"value": "ON"
+		}
+	},
+	"nextTimeBlock": {
+		"start": "2020-03-05T08:00:00.000Z"
+	},
+	"preparation": null,
+	"overlayType": "MANUAL",
+	"nextScheduleChange": null,
+	"setting": {
+		"type": "AIR_CONDITIONING",
+		"mode": "FAN",
+		"power": "ON"
+	}
+}

--- a/tests/fixtures/smartac3.heat_mode.json
+++ b/tests/fixtures/smartac3.heat_mode.json
@@ -1,0 +1,67 @@
+{
+	"tadoMode": "HOME",
+	"sensorDataPoints": {
+		"insideTemperature": {
+			"fahrenheit": 76.57,
+			"timestamp": "2020-03-05T03:57:38.850Z",
+			"celsius": 24.76,
+			"type": "TEMPERATURE",
+			"precision": {
+				"fahrenheit": 0.1,
+				"celsius": 0.1
+			}
+		},
+		"humidity": {
+			"timestamp": "2020-03-05T03:57:38.850Z",
+			"percentage": 60.9,
+			"type": "PERCENTAGE"
+		}
+	},
+	"link": {
+		"state": "ONLINE"
+	},
+	"openWindow": null,
+	"geolocationOverride": false,
+	"geolocationOverrideDisableTime": null,
+	"overlay": {
+		"termination": {
+			"typeSkillBasedApp": "TADO_MODE",
+			"projectedExpiry": null,
+			"type": "TADO_MODE"
+		},
+		"setting": {
+			"fanSpeed": "AUTO",
+			"type": "AIR_CONDITIONING",
+			"mode": "HEAT",
+			"power": "ON",
+			"temperature": {
+				"fahrenheit": 61.0,
+				"celsius": 16.11
+			}
+		},
+		"type": "MANUAL"
+	},
+	"activityDataPoints": {
+		"acPower": {
+			"timestamp": "2020-03-05T03:59:36.390Z",
+			"type": "POWER",
+			"value": "ON"
+		}
+	},
+	"nextTimeBlock": {
+		"start": "2020-03-05T08:00:00.000Z"
+	},
+	"preparation": null,
+	"overlayType": "MANUAL",
+	"nextScheduleChange": null,
+	"setting": {
+		"fanSpeed": "AUTO",
+		"type": "AIR_CONDITIONING",
+		"mode": "HEAT",
+		"power": "ON",
+		"temperature": {
+			"fahrenheit": 61.0,
+			"celsius": 16.11
+		}
+	}
+}

--- a/tests/fixtures/smartac3.hvac_off.json
+++ b/tests/fixtures/smartac3.hvac_off.json
@@ -1,0 +1,55 @@
+{
+	"tadoMode": "AWAY",
+	"sensorDataPoints": {
+		"insideTemperature": {
+			"fahrenheit": 70.59,
+			"timestamp": "2020-03-05T01:21:44.089Z",
+			"celsius": 21.44,
+			"type": "TEMPERATURE",
+			"precision": {
+				"fahrenheit": 0.1,
+				"celsius": 0.1
+			}
+		},
+		"humidity": {
+			"timestamp": "2020-03-05T01:21:44.089Z",
+			"percentage": 48.2,
+			"type": "PERCENTAGE"
+		}
+	},
+	"link": {
+		"state": "ONLINE"
+	},
+	"openWindow": null,
+	"geolocationOverride": false,
+	"geolocationOverrideDisableTime": null,
+	"overlay": {
+		"termination": {
+			"typeSkillBasedApp": "MANUAL",
+			"projectedExpiry": null,
+			"type": "MANUAL"
+		},
+		"setting": {
+			"type": "AIR_CONDITIONING",
+			"power": "OFF"
+		},
+		"type": "MANUAL"
+	},
+	"activityDataPoints": {
+		"acPower": {
+			"timestamp": "2020-02-29T05:34:10.318Z",
+			"type": "POWER",
+			"value": "OFF"
+		}
+	},
+	"nextTimeBlock": {
+		"start": "2020-03-05T04:00:00.000Z"
+	},
+	"preparation": null,
+	"overlayType": "MANUAL",
+	"nextScheduleChange": null,
+	"setting": {
+		"type": "AIR_CONDITIONING",
+		"power": "OFF"
+	}
+}

--- a/tests/fixtures/smartac3.manual_off.json
+++ b/tests/fixtures/smartac3.manual_off.json
@@ -1,0 +1,55 @@
+{
+	"tadoMode": "HOME",
+	"sensorDataPoints": {
+		"insideTemperature": {
+			"fahrenheit": 77.02,
+			"timestamp": "2020-03-05T04:02:07.396Z",
+			"celsius": 25.01,
+			"type": "TEMPERATURE",
+			"precision": {
+				"fahrenheit": 0.1,
+				"celsius": 0.1
+			}
+		},
+		"humidity": {
+			"timestamp": "2020-03-05T04:02:07.396Z",
+			"percentage": 62.0,
+			"type": "PERCENTAGE"
+		}
+	},
+	"link": {
+		"state": "ONLINE"
+	},
+	"openWindow": null,
+	"geolocationOverride": false,
+	"geolocationOverrideDisableTime": null,
+	"overlay": {
+		"termination": {
+			"typeSkillBasedApp": "MANUAL",
+			"projectedExpiry": null,
+			"type": "MANUAL"
+		},
+		"setting": {
+			"type": "AIR_CONDITIONING",
+			"power": "OFF"
+		},
+		"type": "MANUAL"
+	},
+	"activityDataPoints": {
+		"acPower": {
+			"timestamp": "2020-03-05T04:05:08.804Z",
+			"type": "POWER",
+			"value": "OFF"
+		}
+	},
+	"nextTimeBlock": {
+		"start": "2020-03-05T08:00:00.000Z"
+	},
+	"preparation": null,
+	"overlayType": "MANUAL",
+	"nextScheduleChange": null,
+	"setting": {
+		"type": "AIR_CONDITIONING",
+		"power": "OFF"
+	}
+}

--- a/tests/fixtures/smartac3.offline.json
+++ b/tests/fixtures/smartac3.offline.json
@@ -1,0 +1,71 @@
+{
+	"tadoMode": "HOME",
+	"sensorDataPoints": {
+		"insideTemperature": {
+			"fahrenheit": 77.09,
+			"timestamp": "2020-03-03T21:23:57.846Z",
+			"celsius": 25.05,
+			"type": "TEMPERATURE",
+			"precision": {
+				"fahrenheit": 0.1,
+				"celsius": 0.1
+			}
+		},
+		"humidity": {
+			"timestamp": "2020-03-03T21:23:57.846Z",
+			"percentage": 61.6,
+			"type": "PERCENTAGE"
+		}
+	},
+	"link": {
+		"state": "OFFLINE",
+		"reason": {
+			"code": "disconnectedDevice",
+			"title": "There is a disconnected device."
+		}
+	},
+	"openWindow": null,
+	"geolocationOverride": false,
+	"geolocationOverrideDisableTime": null,
+	"overlay": {
+		"termination": {
+			"typeSkillBasedApp": "TADO_MODE",
+			"projectedExpiry": null,
+			"type": "TADO_MODE"
+		},
+		"setting": {
+			"fanSpeed": "AUTO",
+			"type": "AIR_CONDITIONING",
+			"mode": "COOL",
+			"power": "ON",
+			"temperature": {
+				"fahrenheit": 64.0,
+				"celsius": 17.78
+			}
+		},
+		"type": "MANUAL"
+	},
+	"activityDataPoints": {
+		"acPower": {
+			"timestamp": "2020-02-29T18:42:26.683Z",
+			"type": "POWER",
+			"value": "OFF"
+		}
+	},
+	"nextTimeBlock": {
+		"start": "2020-03-05T08:00:00.000Z"
+	},
+	"preparation": null,
+	"overlayType": "MANUAL",
+	"nextScheduleChange": null,
+	"setting": {
+		"fanSpeed": "AUTO",
+		"type": "AIR_CONDITIONING",
+		"mode": "COOL",
+		"power": "ON",
+		"temperature": {
+			"fahrenheit": 64.0,
+			"celsius": 17.78
+		}
+	}
+}

--- a/tests/fixtures/smartac3.smart_mode.json
+++ b/tests/fixtures/smartac3.smart_mode.json
@@ -1,0 +1,50 @@
+{
+	"tadoMode": "HOME",
+	"sensorDataPoints": {
+		"insideTemperature": {
+			"fahrenheit": 75.97,
+			"timestamp": "2020-03-05T03:50:24.769Z",
+			"celsius": 24.43,
+			"type": "TEMPERATURE",
+			"precision": {
+				"fahrenheit": 0.1,
+				"celsius": 0.1
+			}
+		},
+		"humidity": {
+			"timestamp": "2020-03-05T03:50:24.769Z",
+			"percentage": 60.0,
+			"type": "PERCENTAGE"
+		}
+	},
+	"link": {
+		"state": "ONLINE"
+	},
+	"openWindow": null,
+	"geolocationOverride": false,
+	"geolocationOverrideDisableTime": null,
+	"overlay": null,
+	"activityDataPoints": {
+		"acPower": {
+			"timestamp": "2020-03-05T03:52:22.253Z",
+			"type": "POWER",
+			"value": "OFF"
+		}
+	},
+	"nextTimeBlock": {
+		"start": "2020-03-05T08:00:00.000Z"
+	},
+	"preparation": null,
+	"overlayType": null,
+	"nextScheduleChange": null,
+	"setting": {
+		"fanSpeed": "MIDDLE",
+		"type": "AIR_CONDITIONING",
+		"mode": "COOL",
+		"power": "ON",
+		"temperature": {
+			"fahrenheit": 68.0,
+			"celsius": 20.0
+		}
+	}
+}

--- a/tests/fixtures/smartac3.turning_off.json
+++ b/tests/fixtures/smartac3.turning_off.json
@@ -1,0 +1,55 @@
+{
+	"tadoMode": "HOME",
+	"geolocationOverride": false,
+	"geolocationOverrideDisableTime": null,
+	"preparation": null,
+	"setting": {
+		"type": "AIR_CONDITIONING",
+		"power": "OFF"
+	},
+	"overlayType": "MANUAL",
+	"overlay": {
+		"type": "MANUAL",
+		"setting": {
+			"type": "AIR_CONDITIONING",
+			"power": "OFF"
+		},
+		"termination": {
+			"type": "MANUAL",
+			"typeSkillBasedApp": "MANUAL",
+			"projectedExpiry": null
+		}
+	},
+	"openWindow": null,
+	"nextScheduleChange": null,
+	"nextTimeBlock": {
+		"start": "2020-03-07T04:00:00.000Z"
+	},
+	"link": {
+		"state": "ONLINE"
+	},
+	"activityDataPoints": {
+		"acPower": {
+			"timestamp": "2020-03-06T19:05:21.835Z",
+			"type": "POWER",
+			"value": "ON"
+		}
+	},
+	"sensorDataPoints": {
+		"insideTemperature": {
+			"celsius": 21.40,
+			"fahrenheit": 70.52,
+			"timestamp": "2020-03-06T19:06:13.185Z",
+			"type": "TEMPERATURE",
+			"precision": {
+				"celsius": 0.1,
+				"fahrenheit": 0.1
+			}
+		},
+		"humidity": {
+			"type": "PERCENTAGE",
+			"percentage": 49.20,
+			"timestamp": "2020-03-06T19:06:13.185Z"
+		}
+	}
+}

--- a/tests/fixtures/tadov2.heating.auto_mode.json
+++ b/tests/fixtures/tadov2.heating.auto_mode.json
@@ -1,0 +1,58 @@
+{
+  "tadoMode": "HOME",
+  "geolocationOverride": false,
+  "geolocationOverrideDisableTime": null,
+  "preparation": null,
+  "setting": {
+    "type": "HEATING",
+    "power": "ON",
+    "temperature": {
+      "celsius": 20.00,
+      "fahrenheit": 68.00
+    }
+  },
+  "overlayType": null,
+  "overlay": null,
+  "openWindow": null,
+  "nextScheduleChange": {
+    "start": "2020-03-10T17:00:00Z",
+    "setting": {
+      "type": "HEATING",
+      "power": "ON",
+      "temperature": {
+        "celsius": 21.00,
+        "fahrenheit": 69.80
+      }
+    }
+  },
+  "nextTimeBlock": {
+    "start": "2020-03-10T17:00:00.000Z"
+  },
+  "link": {
+    "state": "ONLINE"
+  },
+  "activityDataPoints": {
+    "heatingPower": {
+      "type": "PERCENTAGE",
+      "percentage": 0.00,
+      "timestamp": "2020-03-10T07:47:45.978Z"
+    }
+  },
+  "sensorDataPoints": {
+    "insideTemperature": {
+      "celsius": 20.65,
+      "fahrenheit": 69.17,
+      "timestamp": "2020-03-10T07:44:11.947Z",
+      "type": "TEMPERATURE",
+      "precision": {
+        "celsius": 0.1,
+        "fahrenheit": 0.1
+      }
+    },
+    "humidity": {
+      "type": "PERCENTAGE",
+      "percentage": 45.20,
+      "timestamp": "2020-03-10T07:44:11.947Z"
+    }
+  }
+}

--- a/tests/fixtures/tadov2.heating.manual_mode.json
+++ b/tests/fixtures/tadov2.heating.manual_mode.json
@@ -1,0 +1,73 @@
+{
+  "tadoMode": "HOME",
+  "geolocationOverride": false,
+  "geolocationOverrideDisableTime": null,
+  "preparation": null,
+  "setting": {
+    "type": "HEATING",
+    "power": "ON",
+    "temperature": {
+      "celsius": 20.50,
+      "fahrenheit": 68.90
+    }
+  },
+  "overlayType": "MANUAL",
+  "overlay": {
+    "type": "MANUAL",
+    "setting": {
+      "type": "HEATING",
+      "power": "ON",
+      "temperature": {
+        "celsius": 20.50,
+        "fahrenheit": 68.90
+      }
+    },
+    "termination": {
+      "type": "MANUAL",
+      "typeSkillBasedApp": "MANUAL",
+      "projectedExpiry": null
+    }
+  },
+  "openWindow": null,
+  "nextScheduleChange": {
+    "start": "2020-03-10T17:00:00Z",
+    "setting": {
+      "type": "HEATING",
+      "power": "ON",
+      "temperature": {
+        "celsius": 21.00,
+        "fahrenheit": 69.80
+      }
+    }
+  },
+  "nextTimeBlock": {
+    "start": "2020-03-10T17:00:00.000Z"
+  },
+  "link": {
+    "state": "ONLINE"
+  },
+  "activityDataPoints": {
+    "heatingPower": {
+      "type": "PERCENTAGE",
+      "percentage": 0.00,
+      "timestamp": "2020-03-10T07:47:45.978Z"
+    }
+  },
+  "sensorDataPoints": {
+    "insideTemperature": {
+      "celsius": 20.65,
+      "fahrenheit": 69.17,
+      "timestamp": "2020-03-10T07:44:11.947Z",
+      "type": "TEMPERATURE",
+      "precision": {
+        "celsius": 0.1,
+        "fahrenheit": 0.1
+      }
+    },
+    "humidity": {
+      "type": "PERCENTAGE",
+      "percentage": 45.20,
+      "timestamp": "2020-03-10T07:44:11.947Z"
+    }
+  }
+}

--- a/tests/fixtures/tadov2.heating.off_mode.json
+++ b/tests/fixtures/tadov2.heating.off_mode.json
@@ -1,0 +1,67 @@
+{
+  "tadoMode": "HOME",
+  "geolocationOverride": false,
+  "geolocationOverrideDisableTime": null,
+  "preparation": null,
+  "setting": {
+    "type": "HEATING",
+    "power": "OFF",
+    "temperature": null
+  },
+  "overlayType": "MANUAL",
+  "overlay": {
+    "type": "MANUAL",
+    "setting": {
+      "type": "HEATING",
+      "power": "OFF",
+      "temperature": null
+    },
+    "termination": {
+      "type": "MANUAL",
+      "typeSkillBasedApp": "MANUAL",
+      "projectedExpiry": null
+    }
+  },
+  "openWindow": null,
+  "nextScheduleChange": {
+    "start": "2020-03-10T17:00:00Z",
+    "setting": {
+      "type": "HEATING",
+      "power": "ON",
+      "temperature": {
+        "celsius": 21.00,
+        "fahrenheit": 69.80
+      }
+    }
+  },
+  "nextTimeBlock": {
+    "start": "2020-03-10T17:00:00.000Z"
+  },
+  "link": {
+    "state": "ONLINE"
+  },
+  "activityDataPoints": {
+    "heatingPower": {
+      "type": "PERCENTAGE",
+      "percentage": 0.00,
+      "timestamp": "2020-03-10T07:47:45.978Z"
+    }
+  },
+  "sensorDataPoints": {
+    "insideTemperature": {
+      "celsius": 20.65,
+      "fahrenheit": 69.17,
+      "timestamp": "2020-03-10T07:44:11.947Z",
+      "type": "TEMPERATURE",
+      "precision": {
+        "celsius": 0.1,
+        "fahrenheit": 0.1
+      }
+    },
+    "humidity": {
+      "type": "PERCENTAGE",
+      "percentage": 45.20,
+      "timestamp": "2020-03-10T07:44:11.947Z"
+    }
+  }
+}

--- a/tests/fixtures/tadov2.water_heater.auto_mode.json
+++ b/tests/fixtures/tadov2.water_heater.auto_mode.json
@@ -1,0 +1,33 @@
+{
+  "tadoMode": "HOME",
+  "geolocationOverride": false,
+  "geolocationOverrideDisableTime": null,
+  "preparation": null,
+  "setting": {
+    "type": "HOT_WATER",
+    "power": "ON",
+    "temperature": {
+      "celsius": 65.00,
+      "fahrenheit": 149.00
+    }
+  },
+  "overlayType": null,
+  "overlay": null,
+  "openWindow": null,
+  "nextScheduleChange": {
+    "start": "2020-03-10T22:00:00Z",
+    "setting": {
+      "type": "HOT_WATER",
+      "power": "OFF",
+      "temperature": null
+    }
+  },
+  "nextTimeBlock": {
+    "start": "2020-03-10T22:00:00.000Z"
+  },
+  "link": {
+    "state": "ONLINE"
+  },
+  "activityDataPoints": {},
+  "sensorDataPoints": {}
+}

--- a/tests/fixtures/tadov2.water_heater.manual_mode.json
+++ b/tests/fixtures/tadov2.water_heater.manual_mode.json
@@ -1,0 +1,48 @@
+{
+  "tadoMode": "HOME",
+  "geolocationOverride": false,
+  "geolocationOverrideDisableTime": null,
+  "preparation": null,
+  "setting": {
+    "type": "HOT_WATER",
+    "power": "ON",
+    "temperature": {
+      "celsius": 55.00,
+      "fahrenheit": 131.00
+    }
+  },
+  "overlayType": "MANUAL",
+  "overlay": {
+    "type": "MANUAL",
+    "setting": {
+      "type": "HOT_WATER",
+      "power": "ON",
+      "temperature": {
+        "celsius": 55.00,
+        "fahrenheit": 131.00
+      }
+    },
+    "termination": {
+      "type": "MANUAL",
+      "typeSkillBasedApp": "MANUAL",
+      "projectedExpiry": null
+    }
+  },
+  "openWindow": null,
+  "nextScheduleChange": {
+    "start": "2020-03-10T22:00:00Z",
+    "setting": {
+      "type": "HOT_WATER",
+      "power": "OFF",
+      "temperature": null
+    }
+  },
+  "nextTimeBlock": {
+    "start": "2020-03-10T22:00:00.000Z"
+  },
+  "link": {
+    "state": "ONLINE"
+  },
+  "activityDataPoints": {},
+  "sensorDataPoints": {}
+}

--- a/tests/fixtures/tadov2.water_heater.off_mode.json
+++ b/tests/fixtures/tadov2.water_heater.off_mode.json
@@ -1,0 +1,42 @@
+{
+  "tadoMode": "HOME",
+  "geolocationOverride": false,
+  "geolocationOverrideDisableTime": null,
+  "preparation": null,
+  "setting": {
+    "type": "HOT_WATER",
+    "power": "OFF",
+    "temperature": null
+  },
+  "overlayType": "MANUAL",
+  "overlay": {
+    "type": "MANUAL",
+    "setting": {
+      "type": "HOT_WATER",
+      "power": "OFF",
+      "temperature": null
+    },
+    "termination": {
+      "type": "MANUAL",
+      "typeSkillBasedApp": "MANUAL",
+      "projectedExpiry": null
+    }
+  },
+  "openWindow": null,
+  "nextScheduleChange": {
+    "start": "2020-03-10T22:00:00Z",
+    "setting": {
+      "type": "HOT_WATER",
+      "power": "OFF",
+      "temperature": null
+    }
+  },
+  "nextTimeBlock": {
+    "start": "2020-03-10T22:00:00.000Z"
+  },
+  "link": {
+    "state": "ONLINE"
+  },
+  "activityDataPoints": {},
+  "sensorDataPoints": {}
+}

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -1,0 +1,573 @@
+"""Test the TadoZone object."""
+
+import os
+import json
+from unittest.mock import patch
+
+from PyTado.interface import Tado
+
+
+def _mock_tado_climate_zone_from_fixture(filename):
+    with patch("PyTado.interface.Tado._loginV2"), patch(
+        "PyTado.interface.Tado.getMe"
+    ), patch("PyTado.interface.Tado.getState", return_value=json.loads(load_fixture(filename))):
+        tado = Tado("my@username.com", "mypassword")
+        return tado.getZoneState(1)
+
+
+def load_fixture(filename):
+    """Load a fixture."""
+    path = os.path.join(os.path.dirname(__file__), "fixtures", filename)
+    with open(path) as fptr:
+        return fptr.read()
+
+
+async def test_ac_issue_32294_heat_mode():
+    """Test smart ac cool mode."""
+    ac_issue_32294_heat_mode = _mock_tado_climate_zone_from_fixture(
+        "ac_issue_32294.heat_mode.json"
+    )
+    assert ac_issue_32294_heat_mode.preparation is False
+    assert ac_issue_32294_heat_mode.open_window is False
+    assert ac_issue_32294_heat_mode.open_window_attr == {}
+    assert ac_issue_32294_heat_mode.current_temp == 21.82
+    assert ac_issue_32294_heat_mode.current_temp_timestamp == "2020-02-29T22:51:05.016Z"
+    assert ac_issue_32294_heat_mode.connection is None
+    assert ac_issue_32294_heat_mode.tado_mode == "HOME"
+    assert ac_issue_32294_heat_mode.overlay_active is False
+    assert ac_issue_32294_heat_mode.overlay_termination_type is None
+    assert ac_issue_32294_heat_mode.current_humidity == 40.4
+    assert (
+        ac_issue_32294_heat_mode.current_humidity_timestamp
+        == "2020-02-29T22:51:05.016Z"
+    )
+    assert ac_issue_32294_heat_mode.ac_power_timestamp == "2020-02-29T22:50:34.850Z"
+    assert ac_issue_32294_heat_mode.heating_power_timestamp is None
+    assert ac_issue_32294_heat_mode.ac_power == "ON"
+    assert ac_issue_32294_heat_mode.heating_power is None
+    assert ac_issue_32294_heat_mode.heating_power_percentage is None
+    assert ac_issue_32294_heat_mode.is_away is False
+    assert ac_issue_32294_heat_mode.power == "ON"
+    assert ac_issue_32294_heat_mode.current_hvac_action == "HEATING"
+    assert ac_issue_32294_heat_mode.current_fan_speed == "AUTO"
+    assert ac_issue_32294_heat_mode.link == "ONLINE"
+    assert ac_issue_32294_heat_mode.current_hvac_mode == "SMART_SCHEDULE"
+    assert ac_issue_32294_heat_mode.target_temp == 25.0
+    assert ac_issue_32294_heat_mode.available is True
+    assert ac_issue_32294_heat_mode.precision == 0.1
+
+
+async def test_smartac3_smart_mode():
+    """Test smart ac smart mode."""
+    smartac3_smart_mode = _mock_tado_climate_zone_from_fixture(
+        "smartac3.smart_mode.json"
+    )
+    assert smartac3_smart_mode.preparation is False
+    assert smartac3_smart_mode.open_window is False
+    assert smartac3_smart_mode.open_window_attr == {}
+    assert smartac3_smart_mode.current_temp == 24.43
+    assert smartac3_smart_mode.current_temp_timestamp == "2020-03-05T03:50:24.769Z"
+    assert smartac3_smart_mode.connection is None
+    assert smartac3_smart_mode.tado_mode == "HOME"
+    assert smartac3_smart_mode.overlay_active is False
+    assert smartac3_smart_mode.overlay_termination_type is None
+    assert smartac3_smart_mode.current_humidity == 60.0
+    assert smartac3_smart_mode.current_humidity_timestamp == "2020-03-05T03:50:24.769Z"
+    assert smartac3_smart_mode.ac_power_timestamp == "2020-03-05T03:52:22.253Z"
+    assert smartac3_smart_mode.heating_power_timestamp is None
+    assert smartac3_smart_mode.ac_power == "OFF"
+    assert smartac3_smart_mode.heating_power is None
+    assert smartac3_smart_mode.heating_power_percentage is None
+    assert smartac3_smart_mode.is_away is False
+    assert smartac3_smart_mode.power == "ON"
+    assert smartac3_smart_mode.current_hvac_action == "IDLE"
+    assert smartac3_smart_mode.current_fan_speed == "MIDDLE"
+    assert smartac3_smart_mode.link == "ONLINE"
+    assert smartac3_smart_mode.current_hvac_mode == "SMART_SCHEDULE"
+    assert smartac3_smart_mode.target_temp == 20.0
+    assert smartac3_smart_mode.available is True
+    assert smartac3_smart_mode.precision == 0.1
+
+
+async def test_smartac3_cool_mode():
+    """Test smart ac cool mode."""
+    smartac3_cool_mode = _mock_tado_climate_zone_from_fixture("smartac3.cool_mode.json")
+    assert smartac3_cool_mode.preparation is False
+    assert smartac3_cool_mode.open_window is False
+    assert smartac3_cool_mode.open_window_attr == {}
+    assert smartac3_cool_mode.current_temp == 24.76
+    assert smartac3_cool_mode.current_temp_timestamp == "2020-03-05T03:57:38.850Z"
+    assert smartac3_cool_mode.connection is None
+    assert smartac3_cool_mode.tado_mode == "HOME"
+    assert smartac3_cool_mode.overlay_active is True
+    assert smartac3_cool_mode.overlay_termination_type == "TADO_MODE"
+    assert smartac3_cool_mode.current_humidity == 60.9
+    assert smartac3_cool_mode.current_humidity_timestamp == "2020-03-05T03:57:38.850Z"
+    assert smartac3_cool_mode.ac_power_timestamp == "2020-03-05T04:01:07.162Z"
+    assert smartac3_cool_mode.heating_power_timestamp is None
+    assert smartac3_cool_mode.ac_power == "ON"
+    assert smartac3_cool_mode.heating_power is None
+    assert smartac3_cool_mode.heating_power_percentage is None
+    assert smartac3_cool_mode.is_away is False
+    assert smartac3_cool_mode.power == "ON"
+    assert smartac3_cool_mode.current_hvac_action == "COOLING"
+    assert smartac3_cool_mode.current_fan_speed == "AUTO"
+    assert smartac3_cool_mode.link == "ONLINE"
+    assert smartac3_cool_mode.current_hvac_mode == "COOL"
+    assert smartac3_cool_mode.target_temp == 17.78
+    assert smartac3_cool_mode.available is True
+    assert smartac3_cool_mode.precision == 0.1
+
+
+async def test_smartac3_auto_mode():
+    """Test smart ac cool mode."""
+    smartac3_auto_mode = _mock_tado_climate_zone_from_fixture("smartac3.auto_mode.json")
+    assert smartac3_auto_mode.preparation is False
+    assert smartac3_auto_mode.open_window is False
+    assert smartac3_auto_mode.open_window_attr == {}
+    assert smartac3_auto_mode.current_temp == 24.8
+    assert smartac3_auto_mode.current_temp_timestamp == "2020-03-05T03:55:38.160Z"
+    assert smartac3_auto_mode.connection is None
+    assert smartac3_auto_mode.tado_mode == "HOME"
+    assert smartac3_auto_mode.overlay_active is True
+    assert smartac3_auto_mode.overlay_termination_type == "TADO_MODE"
+    assert smartac3_auto_mode.current_humidity == 62.5
+    assert smartac3_auto_mode.current_humidity_timestamp == "2020-03-05T03:55:38.160Z"
+    assert smartac3_auto_mode.ac_power_timestamp == "2020-03-05T03:56:38.627Z"
+    assert smartac3_auto_mode.heating_power_timestamp is None
+    assert smartac3_auto_mode.ac_power == "ON"
+    assert smartac3_auto_mode.heating_power is None
+    assert smartac3_auto_mode.heating_power_percentage is None
+    assert smartac3_auto_mode.is_away is False
+    assert smartac3_auto_mode.power == "ON"
+    assert smartac3_auto_mode.current_hvac_action == "COOLING"
+    assert smartac3_auto_mode.current_fan_speed == "AUTO"
+    assert smartac3_auto_mode.link == "ONLINE"
+    assert smartac3_auto_mode.current_hvac_mode == "AUTO"
+    assert smartac3_auto_mode.target_temp is None
+    assert smartac3_auto_mode.available is True
+    assert smartac3_auto_mode.precision == 0.1
+
+
+async def test_smartac3_dry_mode():
+    """Test smart ac cool mode."""
+    smartac3_dry_mode = _mock_tado_climate_zone_from_fixture("smartac3.dry_mode.json")
+    assert smartac3_dry_mode.preparation is False
+    assert smartac3_dry_mode.open_window is False
+    assert smartac3_dry_mode.open_window_attr == {}
+    assert smartac3_dry_mode.current_temp == 25.01
+    assert smartac3_dry_mode.current_temp_timestamp == "2020-03-05T04:02:07.396Z"
+    assert smartac3_dry_mode.connection is None
+    assert smartac3_dry_mode.tado_mode == "HOME"
+    assert smartac3_dry_mode.overlay_active is True
+    assert smartac3_dry_mode.overlay_termination_type == "TADO_MODE"
+    assert smartac3_dry_mode.current_humidity == 62.0
+    assert smartac3_dry_mode.current_humidity_timestamp == "2020-03-05T04:02:07.396Z"
+    assert smartac3_dry_mode.ac_power_timestamp == "2020-03-05T04:02:40.867Z"
+    assert smartac3_dry_mode.heating_power_timestamp is None
+    assert smartac3_dry_mode.ac_power == "ON"
+    assert smartac3_dry_mode.heating_power is None
+    assert smartac3_dry_mode.heating_power_percentage is None
+    assert smartac3_dry_mode.is_away is False
+    assert smartac3_dry_mode.power == "ON"
+    assert smartac3_dry_mode.current_hvac_action == "DRYING"
+    assert smartac3_dry_mode.current_fan_speed == "AUTO"
+    assert smartac3_dry_mode.link == "ONLINE"
+    assert smartac3_dry_mode.current_hvac_mode == "DRY"
+    assert smartac3_dry_mode.target_temp is None
+    assert smartac3_dry_mode.available is True
+    assert smartac3_dry_mode.precision == 0.1
+
+
+async def test_smartac3_fan_mode():
+    """Test smart ac cool mode."""
+    smartac3_fan_mode = _mock_tado_climate_zone_from_fixture("smartac3.fan_mode.json")
+    assert smartac3_fan_mode.preparation is False
+    assert smartac3_fan_mode.open_window is False
+    assert smartac3_fan_mode.open_window_attr == {}
+    assert smartac3_fan_mode.current_temp == 25.01
+    assert smartac3_fan_mode.current_temp_timestamp == "2020-03-05T04:02:07.396Z"
+    assert smartac3_fan_mode.connection is None
+    assert smartac3_fan_mode.tado_mode == "HOME"
+    assert smartac3_fan_mode.overlay_active is True
+    assert smartac3_fan_mode.overlay_termination_type == "TADO_MODE"
+    assert smartac3_fan_mode.current_humidity == 62.0
+    assert smartac3_fan_mode.current_humidity_timestamp == "2020-03-05T04:02:07.396Z"
+    assert smartac3_fan_mode.ac_power_timestamp == "2020-03-05T04:03:44.328Z"
+    assert smartac3_fan_mode.heating_power_timestamp is None
+    assert smartac3_fan_mode.ac_power == "ON"
+    assert smartac3_fan_mode.heating_power is None
+    assert smartac3_fan_mode.heating_power_percentage is None
+    assert smartac3_fan_mode.is_away is False
+    assert smartac3_fan_mode.power == "ON"
+    assert smartac3_fan_mode.current_hvac_action == "FAN"
+    assert smartac3_fan_mode.current_fan_speed == "AUTO"
+    assert smartac3_fan_mode.link == "ONLINE"
+    assert smartac3_fan_mode.current_hvac_mode == "FAN"
+    assert smartac3_fan_mode.target_temp is None
+    assert smartac3_fan_mode.available is True
+    assert smartac3_fan_mode.precision == 0.1
+
+
+async def test_smartac3_heat_mode():
+    """Test smart ac cool mode."""
+    smartac3_heat_mode = _mock_tado_climate_zone_from_fixture("smartac3.heat_mode.json")
+    assert smartac3_heat_mode.preparation is False
+    assert smartac3_heat_mode.open_window is False
+    assert smartac3_heat_mode.open_window_attr == {}
+    assert smartac3_heat_mode.current_temp == 24.76
+    assert smartac3_heat_mode.current_temp_timestamp == "2020-03-05T03:57:38.850Z"
+    assert smartac3_heat_mode.connection is None
+    assert smartac3_heat_mode.tado_mode == "HOME"
+    assert smartac3_heat_mode.overlay_active is True
+    assert smartac3_heat_mode.overlay_termination_type == "TADO_MODE"
+    assert smartac3_heat_mode.current_humidity == 60.9
+    assert smartac3_heat_mode.current_humidity_timestamp == "2020-03-05T03:57:38.850Z"
+    assert smartac3_heat_mode.ac_power_timestamp == "2020-03-05T03:59:36.390Z"
+    assert smartac3_heat_mode.heating_power_timestamp is None
+    assert smartac3_heat_mode.ac_power == "ON"
+    assert smartac3_heat_mode.heating_power is None
+    assert smartac3_heat_mode.heating_power_percentage is None
+    assert smartac3_heat_mode.is_away is False
+    assert smartac3_heat_mode.power == "ON"
+    assert smartac3_heat_mode.current_hvac_action == "HEATING"
+    assert smartac3_heat_mode.current_fan_speed == "AUTO"
+    assert smartac3_heat_mode.link == "ONLINE"
+    assert smartac3_heat_mode.current_hvac_mode == "HEAT"
+    assert smartac3_heat_mode.target_temp == 16.11
+    assert smartac3_heat_mode.available is True
+    assert smartac3_heat_mode.precision == 0.1
+
+
+async def test_smartac3_hvac_off():
+    """Test smart ac cool mode."""
+    smartac3_hvac_off = _mock_tado_climate_zone_from_fixture("smartac3.hvac_off.json")
+    assert smartac3_hvac_off.preparation is False
+    assert smartac3_hvac_off.open_window is False
+    assert smartac3_hvac_off.open_window_attr == {}
+    assert smartac3_hvac_off.current_temp == 21.44
+    assert smartac3_hvac_off.current_temp_timestamp == "2020-03-05T01:21:44.089Z"
+    assert smartac3_hvac_off.connection is None
+    assert smartac3_hvac_off.tado_mode == "AWAY"
+    assert smartac3_hvac_off.overlay_active is True
+    assert smartac3_hvac_off.overlay_termination_type == "MANUAL"
+    assert smartac3_hvac_off.current_humidity == 48.2
+    assert smartac3_hvac_off.current_humidity_timestamp == "2020-03-05T01:21:44.089Z"
+    assert smartac3_hvac_off.ac_power_timestamp == "2020-02-29T05:34:10.318Z"
+    assert smartac3_hvac_off.heating_power_timestamp is None
+    assert smartac3_hvac_off.ac_power == "OFF"
+    assert smartac3_hvac_off.heating_power is None
+    assert smartac3_hvac_off.heating_power_percentage is None
+    assert smartac3_hvac_off.is_away is True
+    assert smartac3_hvac_off.power == "OFF"
+    assert smartac3_hvac_off.current_hvac_action == "OFF"
+    assert smartac3_hvac_off.current_fan_speed == "OFF"
+    assert smartac3_hvac_off.link == "ONLINE"
+    assert smartac3_hvac_off.current_hvac_mode == "OFF"
+    assert smartac3_hvac_off.target_temp is None
+    assert smartac3_hvac_off.available is True
+    assert smartac3_hvac_off.precision == 0.1
+
+
+async def test_smartac3_manual_off():
+    """Test smart ac cool mode."""
+    smartac3_manual_off = _mock_tado_climate_zone_from_fixture(
+        "smartac3.manual_off.json"
+    )
+    assert smartac3_manual_off.preparation is False
+    assert smartac3_manual_off.open_window is False
+    assert smartac3_manual_off.open_window_attr == {}
+    assert smartac3_manual_off.current_temp == 25.01
+    assert smartac3_manual_off.current_temp_timestamp == "2020-03-05T04:02:07.396Z"
+    assert smartac3_manual_off.connection is None
+    assert smartac3_manual_off.tado_mode == "HOME"
+    assert smartac3_manual_off.overlay_active is True
+    assert smartac3_manual_off.overlay_termination_type == "MANUAL"
+    assert smartac3_manual_off.current_humidity == 62.0
+    assert smartac3_manual_off.current_humidity_timestamp == "2020-03-05T04:02:07.396Z"
+    assert smartac3_manual_off.ac_power_timestamp == "2020-03-05T04:05:08.804Z"
+    assert smartac3_manual_off.heating_power_timestamp is None
+    assert smartac3_manual_off.ac_power == "OFF"
+    assert smartac3_manual_off.heating_power is None
+    assert smartac3_manual_off.heating_power_percentage is None
+    assert smartac3_manual_off.is_away is False
+    assert smartac3_manual_off.power == "OFF"
+    assert smartac3_manual_off.current_hvac_action == "OFF"
+    assert smartac3_manual_off.current_fan_speed == "OFF"
+    assert smartac3_manual_off.link == "ONLINE"
+    assert smartac3_manual_off.current_hvac_mode == "OFF"
+    assert smartac3_manual_off.target_temp is None
+    assert smartac3_manual_off.available is True
+    assert smartac3_manual_off.precision == 0.1
+
+
+async def test_smartac3_offline():
+    """Test smart ac cool mode."""
+    smartac3_offline = _mock_tado_climate_zone_from_fixture("smartac3.offline.json")
+    assert smartac3_offline.preparation is False
+    assert smartac3_offline.open_window is False
+    assert smartac3_offline.open_window_attr == {}
+    assert smartac3_offline.current_temp == 25.05
+    assert smartac3_offline.current_temp_timestamp == "2020-03-03T21:23:57.846Z"
+    assert smartac3_offline.connection is None
+    assert smartac3_offline.tado_mode == "HOME"
+    assert smartac3_offline.overlay_active is True
+    assert smartac3_offline.overlay_termination_type == "TADO_MODE"
+    assert smartac3_offline.current_humidity == 61.6
+    assert smartac3_offline.current_humidity_timestamp == "2020-03-03T21:23:57.846Z"
+    assert smartac3_offline.ac_power_timestamp == "2020-02-29T18:42:26.683Z"
+    assert smartac3_offline.heating_power_timestamp is None
+    assert smartac3_offline.ac_power == "OFF"
+    assert smartac3_offline.heating_power is None
+    assert smartac3_offline.heating_power_percentage is None
+    assert smartac3_offline.is_away is False
+    assert smartac3_offline.power == "ON"
+    assert smartac3_offline.current_hvac_action == "IDLE"
+    assert smartac3_offline.current_fan_speed == "AUTO"
+    assert smartac3_offline.link == "OFFLINE"
+    assert smartac3_offline.current_hvac_mode == "COOL"
+    assert smartac3_offline.target_temp == 17.78
+    assert smartac3_offline.available is False
+    assert smartac3_offline.precision == 0.1
+
+
+async def test_hvac_action_heat():
+    """Test smart ac cool mode."""
+    hvac_action_heat = _mock_tado_climate_zone_from_fixture("hvac_action_heat.json")
+    assert hvac_action_heat.preparation is False
+    assert hvac_action_heat.open_window is False
+    assert hvac_action_heat.open_window_attr == {}
+    assert hvac_action_heat.current_temp == 21.4
+    assert hvac_action_heat.current_temp_timestamp == "2020-03-06T18:06:09.546Z"
+    assert hvac_action_heat.connection is None
+    assert hvac_action_heat.tado_mode == "HOME"
+    assert hvac_action_heat.overlay_active is True
+    assert hvac_action_heat.overlay_termination_type == "TADO_MODE"
+    assert hvac_action_heat.current_humidity == 50.4
+    assert hvac_action_heat.current_humidity_timestamp == "2020-03-06T18:06:09.546Z"
+    assert hvac_action_heat.ac_power_timestamp == "2020-03-06T17:38:30.302Z"
+    assert hvac_action_heat.heating_power_timestamp is None
+    assert hvac_action_heat.ac_power == "OFF"
+    assert hvac_action_heat.heating_power is None
+    assert hvac_action_heat.heating_power_percentage is None
+    assert hvac_action_heat.is_away is False
+    assert hvac_action_heat.power == "ON"
+    assert hvac_action_heat.current_hvac_action == "IDLE"
+    assert hvac_action_heat.current_fan_speed == "AUTO"
+    assert hvac_action_heat.link == "ONLINE"
+    assert hvac_action_heat.current_hvac_mode == "HEAT"
+    assert hvac_action_heat.target_temp == 16.11
+    assert hvac_action_heat.available is True
+    assert hvac_action_heat.precision == 0.1
+
+
+async def test_smartac3_turning_off():
+    """Test smart ac cool mode."""
+    smartac3_turning_off = _mock_tado_climate_zone_from_fixture(
+        "smartac3.turning_off.json"
+    )
+    assert smartac3_turning_off.preparation is False
+    assert smartac3_turning_off.open_window is False
+    assert smartac3_turning_off.open_window_attr == {}
+    assert smartac3_turning_off.current_temp == 21.4
+    assert smartac3_turning_off.current_temp_timestamp == "2020-03-06T19:06:13.185Z"
+    assert smartac3_turning_off.connection is None
+    assert smartac3_turning_off.tado_mode == "HOME"
+    assert smartac3_turning_off.overlay_active is True
+    assert smartac3_turning_off.overlay_termination_type == "MANUAL"
+    assert smartac3_turning_off.current_humidity == 49.2
+    assert smartac3_turning_off.current_humidity_timestamp == "2020-03-06T19:06:13.185Z"
+    assert smartac3_turning_off.ac_power_timestamp == "2020-03-06T19:05:21.835Z"
+    assert smartac3_turning_off.heating_power_timestamp is None
+    assert smartac3_turning_off.ac_power == "ON"
+    assert smartac3_turning_off.heating_power is None
+    assert smartac3_turning_off.heating_power_percentage is None
+    assert smartac3_turning_off.is_away is False
+    assert smartac3_turning_off.power == "OFF"
+    assert smartac3_turning_off.current_hvac_action == "OFF"
+    assert smartac3_turning_off.current_fan_speed == "OFF"
+    assert smartac3_turning_off.link == "ONLINE"
+    assert smartac3_turning_off.current_hvac_mode == "OFF"
+    assert smartac3_turning_off.target_temp is None
+    assert smartac3_turning_off.available is True
+    assert smartac3_turning_off.precision == 0.1
+
+
+async def test_tadov2_heating_auto_mode():
+    """Test tadov2 heating auto mode."""
+    mode = _mock_tado_climate_zone_from_fixture("tadov2.heating.auto_mode.json")
+    assert mode.preparation is False
+    assert mode.open_window is False
+    assert mode.open_window_attr == {}
+    assert mode.current_temp == 20.65
+    assert mode.current_temp_timestamp == "2020-03-10T07:44:11.947Z"
+    assert mode.connection is None
+    assert mode.tado_mode == "HOME"
+    assert mode.overlay_active is False
+    assert mode.overlay_termination_type is None
+    assert mode.current_humidity == 45.20
+    assert mode.current_humidity_timestamp == "2020-03-10T07:44:11.947Z"
+    assert mode.ac_power_timestamp is None
+    assert mode.heating_power_timestamp == "2020-03-10T07:47:45.978Z"
+    assert mode.ac_power is None
+    assert mode.heating_power is None
+    assert mode.heating_power_percentage == 0.0
+    assert mode.is_away is False
+    assert mode.power == "ON"
+    assert mode.current_hvac_action == "IDLE"
+    assert mode.current_fan_speed is None
+    assert mode.link == "ONLINE"
+    assert mode.current_hvac_mode == "SMART_SCHEDULE"
+    assert mode.target_temp == 20.0
+    assert mode.available is True
+    assert mode.precision == 0.1
+
+
+async def test_tadov2_heating_manual_mode():
+    """Test tadov2 heating manual mode."""
+    mode = _mock_tado_climate_zone_from_fixture("tadov2.heating.manual_mode.json")
+    assert mode.preparation is False
+    assert mode.open_window is False
+    assert mode.open_window_attr == {}
+    assert mode.current_temp == 20.65
+    assert mode.current_temp_timestamp == "2020-03-10T07:44:11.947Z"
+    assert mode.connection is None
+    assert mode.tado_mode == "HOME"
+    assert mode.overlay_active is True
+    assert mode.overlay_termination_type == "MANUAL"
+    assert mode.current_humidity == 45.2
+    assert mode.current_humidity_timestamp == "2020-03-10T07:44:11.947Z"
+    assert mode.ac_power_timestamp is None
+    assert mode.heating_power_timestamp == "2020-03-10T07:47:45.978Z"
+    assert mode.ac_power is None
+    assert mode.heating_power is None
+    assert mode.heating_power_percentage == 0.0
+    assert mode.is_away is False
+    assert mode.power == "ON"
+    assert mode.current_hvac_action == "IDLE"
+    assert mode.current_fan_speed is None
+    assert mode.link == "ONLINE"
+    assert mode.current_hvac_mode == "HEAT"
+    assert mode.target_temp == 20.5
+    assert mode.available is True
+    assert mode.precision == 0.1
+
+
+async def test_tadov2_heating_off_mode():
+    """Test tadov2 heating off mode."""
+    mode = _mock_tado_climate_zone_from_fixture("tadov2.heating.off_mode.json")
+    assert mode.preparation is False
+    assert mode.open_window is False
+    assert mode.open_window_attr == {}
+    assert mode.current_temp == 20.65
+    assert mode.current_temp_timestamp == "2020-03-10T07:44:11.947Z"
+    assert mode.connection is None
+    assert mode.tado_mode == "HOME"
+    assert mode.overlay_active is True
+    assert mode.overlay_termination_type == "MANUAL"
+    assert mode.current_humidity == 45.2
+    assert mode.current_humidity_timestamp == "2020-03-10T07:44:11.947Z"
+    assert mode.ac_power_timestamp is None
+    assert mode.heating_power_timestamp == "2020-03-10T07:47:45.978Z"
+    assert mode.ac_power is None
+    assert mode.heating_power is None
+    assert mode.heating_power_percentage == 0.0
+    assert mode.is_away is False
+    assert mode.power == "OFF"
+    assert mode.current_hvac_action == "OFF"
+    assert mode.current_fan_speed is None
+    assert mode.link == "ONLINE"
+    assert mode.current_hvac_mode == "OFF"
+    assert mode.target_temp is None
+    assert mode.available is True
+    assert mode.precision == 0.1
+
+
+async def test_tadov2_water_heater_auto_mode():
+    """Test tadov2 water heater auto mode."""
+    mode = _mock_tado_climate_zone_from_fixture("tadov2.water_heater.auto_mode.json")
+    assert mode.preparation is False
+    assert mode.open_window is False
+    assert mode.open_window_attr == {}
+    assert mode.current_temp is None
+    assert mode.current_temp_timestamp is None
+    assert mode.connection is None
+    assert mode.tado_mode == "HOME"
+    assert mode.overlay_active is False
+    assert mode.overlay_termination_type is None
+    assert mode.current_humidity is None
+    assert mode.current_humidity_timestamp is None
+    assert mode.ac_power_timestamp is None
+    assert mode.heating_power_timestamp is None
+    assert mode.ac_power is None
+    assert mode.heating_power is None
+    assert mode.heating_power_percentage is None
+    assert mode.is_away is False
+    assert mode.power == "ON"
+    assert mode.current_hvac_action == "IDLE"
+    assert mode.current_fan_speed is None
+    assert mode.link == "ONLINE"
+    assert mode.current_hvac_mode == "SMART_SCHEDULE"
+    assert mode.target_temp == 65.00
+    assert mode.available is True
+    assert mode.precision == 0.1
+
+
+async def test_tadov2_water_heater_manual_mode():
+    """Test tadov2 water heater manual mode."""
+    mode = _mock_tado_climate_zone_from_fixture("tadov2.water_heater.manual_mode.json")
+    assert mode.preparation is False
+    assert mode.open_window is False
+    assert mode.open_window_attr == {}
+    assert mode.current_temp is None
+    assert mode.current_temp_timestamp is None
+    assert mode.connection is None
+    assert mode.tado_mode == "HOME"
+    assert mode.overlay_active is True
+    assert mode.overlay_termination_type == "MANUAL"
+    assert mode.current_humidity is None
+    assert mode.current_humidity_timestamp is None
+    assert mode.ac_power_timestamp is None
+    assert mode.heating_power_timestamp is None
+    assert mode.ac_power is None
+    assert mode.heating_power is None
+    assert mode.heating_power_percentage is None
+    assert mode.is_away is False
+    assert mode.power == "ON"
+    assert mode.current_hvac_action == "IDLE"
+    assert mode.current_fan_speed is None
+    assert mode.link == "ONLINE"
+    assert mode.current_hvac_mode == "HEATING"
+    assert mode.target_temp == 55.00
+    assert mode.available is True
+    assert mode.precision == 0.1
+
+
+async def test_tadov2_water_heater_off_mode():
+    """Test tadov2 water heater off mode."""
+    mode = _mock_tado_climate_zone_from_fixture("tadov2.water_heater.off_mode.json")
+    assert mode.preparation is False
+    assert mode.open_window is False
+    assert mode.open_window_attr == {}
+    assert mode.current_temp is None
+    assert mode.current_temp_timestamp is None
+    assert mode.connection is None
+    assert mode.tado_mode == "HOME"
+    assert mode.overlay_active is True
+    assert mode.overlay_termination_type == "MANUAL"
+    assert mode.current_humidity is None
+    assert mode.current_humidity_timestamp is None
+    assert mode.ac_power_timestamp is None
+    assert mode.heating_power_timestamp is None
+    assert mode.ac_power is None
+    assert mode.heating_power is None
+    assert mode.heating_power_percentage is None
+    assert mode.is_away is False
+    assert mode.power == "OFF"
+    assert mode.current_hvac_action == "OFF"
+    assert mode.current_fan_speed is None
+    assert mode.link == "ONLINE"
+    assert mode.current_hvac_mode == "OFF"
+    assert mode.target_temp is None
+    assert mode.available is True
+    assert mode.precision == 0.1


### PR DESCRIPTION
This creates a new PyTado.zone module that represents a tado zone.  It takes care of normalizing all the attributes in the json api and adds a new getZoneState api call to wrap the api calls of getState.