### PR TITLE
Changed presence command to presenceLock

### DIFF
--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -346,7 +346,6 @@ class Tado:
 
     def setHome(self):
         """Sets HomeState to HOME """
-        # it seems, this can be set anytime
         cmd = 'presenceLock'
         payload = { "homePresence": "HOME" }
         data = self._apiCall(cmd, "PUT", payload)
@@ -354,8 +353,6 @@ class Tado:
 
     def setAway(self):
         """Sets HomeState to AWAY """
-        # this can only be set if everybody left the home and 
-        # showHomePresenceSwitchButton = true
         cmd = 'presenceLock'
         payload = { "homePresence": "AWAY" }
         data = self._apiCall(cmd, "PUT", payload)

--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -347,7 +347,7 @@ class Tado:
     def setHome(self):
         """Sets HomeState to HOME """
         # it seems, this can be set anytime
-        cmd = 'presence'
+        cmd = 'presenceLock'
         payload = { "homePresence": "HOME" }
         data = self._apiCall(cmd, "PUT", payload)
         return data
@@ -356,7 +356,7 @@ class Tado:
         """Sets HomeState to AWAY """
         # this can only be set if everybody left the home and 
         # showHomePresenceSwitchButton = true
-        cmd = 'presence'
+        cmd = 'presenceLock'
         payload = { "homePresence": "AWAY" }
         data = self._apiCall(cmd, "PUT", payload)
         return data


### PR DESCRIPTION
In the latest tado beta app a override switch was added to change presence state manually, even when auto assist is not enabled. This app uses presenceLock instead of presence as the command.

Try
curl -s "https://my.tado.com/api/v2/homes/123456/presenceLock" -H "Authorization: Bearer auth_token" -X PUT -H 'Content-Type: application/json;charset=utf-8' --data '{"homePresence":"AWAY"}'

I have only tested the curl command, not the change to PyTado.