### PR TITLE
Add swing support to setZoneOverlay

### DIFF
--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -324,7 +324,7 @@ class Tado:
         data = self._apiCall(cmd, "DELETE", {}, True)
         return data
 
-    def setZoneOverlay(self, zone, overlayMode, setTemp=None, duration=None, deviceType='HEATING', power="ON", mode=None, fanSpeed=None):
+    def setZoneOverlay(self, zone, overlayMode, setTemp=None, duration=None, deviceType='HEATING', power="ON", mode=None, fanSpeed=None, swing=None):
         """set current overlay for a zone"""
         # pylint: disable=C0103
 
@@ -339,6 +339,8 @@ class Tado:
             post_data["setting"]["temperature"] = {"celsius": setTemp}
             if fanSpeed is not None:
                 post_data["setting"]["fanSpeed"] = fanSpeed
+            if swing is not None:
+                post_data["setting"]["swing"] = swing
 
         if mode is not None:
             post_data["setting"]["mode"] = mode


### PR DESCRIPTION
tado has changed the api as of 25.02.2020 to add swing as a required
value for some smart ac3s.


> Here at tado° we try to optimize our products and to offer the best solution to our customers.
> At the moment we are investigating ways to improve and expand the capabilities of our tado° Smart AC Controller.
> For this we would like to test a new improved command set, which supports the swing function of your AC.
> If you are happy to help us improve the tado° Smart AC Controller please answer this email and we will update your device.
> 
> Thank you very much for your time.
> We look forward to your reply.
> 
> Kind regards,
> tado° Team