### PR TITLE
API call results should be logged as debug

### DIFF
--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -120,7 +120,7 @@ class Tado:
                                      headers={'Content-Type': 'application/json',
                                               'Referer' : 'https://my.tado.com/'})
 
-        _LOGGER.info("api call result: %s", response.text)
+        _LOGGER.debug("api call result: %s", response.text)
         self._setOAuthHeader(response.json())
 
     def _loginV2(self, username, password):


### PR DESCRIPTION
We should use `_LOGGER.debug()` for logging API results. This causes noise in the Home Assistant logs.