### PR TITLE
interface: renew HTTP session on token refresh

### DIFF
--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -115,6 +115,8 @@ class Tado:
                 'grant_type' : 'refresh_token',
                 'scope' : 'home.user',
                 'refresh_token' : self.refresh_token}
+        self._http_session.close()
+        self._http_session = Session()
         # pylint: disable=R0204
         response = self._http_session.request("post", url, params=data, timeout=self.timeout, data=json.dumps({}).encode('utf8'),
                                      headers={'Content-Type': 'application/json',


### PR DESCRIPTION
This is needed in order to prevent connection reset errors:
https://github.com/wmalgadey/PyTado/issues/42
https://github.com/home-assistant/core/issues/41233

Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>