### PR TITLE
Fix change in Tado API around termination in overlay modes. Closes #41

### DIFF
--- a/PyTado/const.py
+++ b/PyTado/const.py
@@ -23,7 +23,7 @@ CONST_FAN_MIDDLE = "MIDDLE"
 CONST_FAN_HIGH = "HIGH"
 
 # When we change the temperature setting, we need an overlay mode
-CONST_OVERLAY_TADO_MODE = "TADO_MODE"  # wait until tado changes the mode automatic
+CONST_OVERLAY_TADO_MODE = "NEXT_TIME_BLOCK"  # wait until tado changes the mode automatic
 CONST_OVERLAY_MANUAL = "MANUAL"  # the user has change the temperature or mode manually
 CONST_OVERLAY_TIMER = "TIMER"  # the temperature will be reset after a timespan
 

--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -337,7 +337,7 @@ class Tado:
 
         post_data = {
             "setting": {"type": deviceType, "power": power},
-            "termination": {"type": overlayMode},
+            "termination": {"typeSkillBasedApp": overlayMode},
         }
 
         if setTemp is not None:


### PR DESCRIPTION
This PR fixes issue https://github.com/wmalgadey/PyTado/issues/41

Tado's API has slightly changed the way they handle termination modes.

I tested and confirmed that both "NEXT_TIME_BLOCK" and "MANUAL" still work.