### PR TITLE
Adding default overlay settings to zone data

### DIFF
--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -362,6 +362,12 @@ class Tado:
 
         data = self._apiCall(cmd, "PUT", post_data)
         return data
+        
+    def getZoneOverlayDefault(self, zone):
+        """Get current overlay default settings for zone."""
+        cmd = 'zones/%i/defaultOverlay' % zone
+        data = self._apiCall(cmd)
+        return data     
 
     def setHome(self):
         """Sets HomeState to HOME """
@@ -411,8 +417,9 @@ class Tado:
         data = self._apiCall(cmd=cmd, domain=self.DEVICE_DOMAIN, device_id=device_id)
         return data
     
-    def setTempOffset(self, device_id, offset=0):
-        offset_data = {"celsius":offset}
+    def setTempOffset(self, device_id, offset=0, measure="celsius"):
+        """Set the Temperature offset on the device."""
+        offset_data = {measure:offset}
         data = self._apiCall(cmd='temperatureOffset', method='PUT', data=offset_data, domain=self.DEVICE_DOMAIN, device_id=device_id)
         return data
     

--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -187,7 +187,7 @@ class Tado:
         # pylint: disable=C0103
 
         cmd = 'zones/%i/state' % zone
-        data = self._apiCall(cmd)
+        data = {**self._apiCall(cmd), self.getZoneOverlayDefault(zone)}
         return data
 
     def getHomeState(self):

--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -187,7 +187,7 @@ class Tado:
         # pylint: disable=C0103
 
         cmd = 'zones/%i/state' % zone
-        data = {**self._apiCall(cmd), self.getZoneOverlayDefault(zone)}
+        data = {**self._apiCall(cmd), **self.getZoneOverlayDefault(zone)}
         return data
 
     def getHomeState(self):

--- a/PyTado/zone.py
+++ b/PyTado/zone.py
@@ -54,6 +54,8 @@ class TadoZone:
         self._open_window_detected = None
         self._open_window_attr = None
         self._precision = DEFAULT_TADO_PRECISION
+        self._default_overlay_termination_type = None
+        self._default_overlay_termination_duration = None
         self.update_data(data)
 
     @property
@@ -190,6 +192,16 @@ class TadoZone:
     def available(self):
         """Device is available and link is up."""
         return self._available
+        
+    @property
+    def default_overlay_termination_type(self):
+        """Zone default overlay type."""
+        return self._default_overlay_termination_type
+        
+    @property
+    def default_overlay_termination_duration(self):
+        """Zone default overlay duration."""
+        return self._default_overlay_termination_duration
 
     def update_data(self, data):
         """Handle update callbacks."""
@@ -318,3 +330,9 @@ class TadoZone:
             data["connectionState"]["value"] if "connectionState" in data else None
         )
         self._available = self._link != CONST_LINK_OFFLINE
+        
+        if "terminationCondition" in data:
+            self._default_overlay_termination_type = data["terminationCondition"].get('type',None)
+            self._default_overlay_termination_duration = data["durationInSeconds"].get('type',None)
+            
+            

--- a/PyTado/zone.py
+++ b/PyTado/zone.py
@@ -333,6 +333,6 @@ class TadoZone:
         
         if "terminationCondition" in data:
             self._default_overlay_termination_type = data["terminationCondition"].get('type',None)
-            self._default_overlay_termination_duration = data["durationInSeconds"].get('type',None)
+            self._default_overlay_termination_duration = data["terminationCondition"].get('durationInSeconds',None)
             
             

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open(here('README.md')).read()
 requirements = [x.strip() for x in open(here('requirements.txt')).readlines()]
 
 setup(name='python-tado',
-      version='0.10.0',
+      version='0.11.0',
       description='PyTado from chrism0dwk, modfied by w.malgadey, diplix, michaelarnauts, LenhartStephan, splifter, syssi, andersonshatch, Yippy, p0thi',
       long_description=readme,
       keywords='tado',


### PR DESCRIPTION
I've added the overlay settings from tado to the zone data. This is so I can get it in Home Assistant and then use it. Once this PR is merged I'll raise the PR to HA

NB also added ability to set the measurement type on temp offset function so you can pass in fahrenheit if you prefer