### PR TITLE
Added support to the `homes/{}/zoneStates` API

### DIFF
--- a/PyTado/__main__.py
+++ b/PyTado/__main__.py
@@ -24,6 +24,11 @@ def get_state(args):
     zone = tado_client.getState(t,int(args.zone))
     print(zone)
 
+def get_states(args):
+    t = log_in(args.email, args.password)
+    zone = tado_client.getZoneStates(t)
+    print(zone)
+
 def get_capabilities(args):
     t = log_in(args.email, args.password)
     capabilities = tado_client.getCapabilities(t,int(args.zone))
@@ -59,6 +64,9 @@ def main():
     start_activity_parser = subparsers.add_parser('get_state', help='Get state of zone.')
     start_activity_parser.add_argument('--zone', help='Zone to get the state of.')
     start_activity_parser.set_defaults(func=get_state)
+
+    start_activity_parser = subparsers.add_parser('get_states', help='Get states of all zones.')
+    start_activity_parser.set_defaults(func=get_states)
 
     start_activity_parser = subparsers.add_parser('get_capabilities', help='Get capabilities of zone.')
     start_activity_parser.add_argument('--zone', help='Zone to get the capabilities of.')

--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -182,6 +182,14 @@ class Tado:
         """Gets current state of Zone as a TadoZone object."""
         return TadoZone(self.getState(zone), zone)
 
+    def getZoneStates(self):
+        """Gets current states of all zones."""
+        # pylint: disable=C0103
+
+        cmd = 'zoneStates'
+        data = self._apiCall(cmd)
+        return data
+
     def getState(self, zone):
         """Gets current state of Zone zone."""
         # pylint: disable=C0103


### PR DESCRIPTION
Instead of iteratively calling the `zones/{}/state` API, the `/zoneStates` API returns the zone states for all zones in one request.