### PR TITLE
add setAuto() to allow geofencing to be re-enabled and bugfix setTimetable()

### DIFF
--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -231,7 +231,7 @@ class Tado:
 
         cmd = 'zones/%i/schedule/activeTimetable' % (zone)
 
-        data = self._apiCall(cmd, "GET", {}, True)
+        data = self._apiCall(cmd, "GET", {}, False)
 
         if "id" in data:
             return Tado.Timetable(data["id"])

--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -390,6 +390,12 @@ class Tado:
         payload = { "homePresence": "AWAY" }
         data = self._apiCall(cmd, "PUT", payload)
         return data
+
+    def setAuto(self):
+        """Sets HomeState to AUTO """
+        cmd = 'presenceLock'
+        data = self._apiCall(cmd, "DELETE", {}, True)
+        return data
     
     def getWindowState(self, zone):
         """Returns the state of the window for Zone zone"""

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open(here('README.md')).read()
 requirements = [x.strip() for x in open(here('requirements.txt')).readlines()]
 
 setup(name='python-tado',
-      version='0.12.0',
+      version='0.13.0',
       description='PyTado from chrism0dwk, modfied by w.malgadey, diplix, michaelarnauts, LenhartStephan, splifter, syssi, andersonshatch, Yippy, p0thi',
       long_description=readme,
       keywords='tado',


### PR DESCRIPTION
- Add setAuto() to allow Set Geofencing back to Auto: Will address https://github.com/wmalgadey/PyTado/issues/52 
- A bug with the get/set timetable stuff was introduced a while ago - I have been using my fork for quite a while now. I use this feature to set different timetables depending on if a particular room is actually occupied.