### PR TITLE
Pass logging debug parameter to http attribute

### DIFF
--- a/PyTado/http/http.py
+++ b/PyTado/http/http.py
@@ -3,6 +3,7 @@ Do all the API HTTP heavy lifting in this file
 """
 
 import json
+import logging
 import pprint
 from datetime import datetime, timedelta
 
@@ -87,8 +88,12 @@ class Http:
     __username = None
     __password = None
 
-    def __init__(self, username=None, password=None, http_session=session):
+    def __init__(self, username=None, password=None, http_session=session, debug=False):
         self.log = Logger(__name__)
+        if debug:
+            self.log.setLevel(logging.DEBUG)
+        else:
+            self.log.setLevel(logging.WARNING)
         self.refresh_at = datetime.now() + timedelta(minutes=5)
         self.session = http_session if http_session else Session()
         self.session.hooks['response'].append(self.__log_response)

--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -41,7 +41,7 @@ class Tado:
         else:
             self.log.setLevel(logging.WARNING)
 
-        self.http = Http(username=username, password=password, http_session=http_session)
+        self.http = Http(username=username, password=password, http_session=http_session, debug=debug)
 
     # <editor-fold desc="Deprecated">
     def getMe(self):


### PR DESCRIPTION
Hi, 👋 

this is a really useful library and I would like to use it as part of a bigger project. For that, I would like to be able to control the logging behaviour of the library in a more granular way:

Currently, the [interface class](https://github.com/markusschanta/PyTado/blob/c07777bf2d8d6886ed519a068c8f5c92a6a08766/PyTado/http/http.py#L91) has a debug parameter but this is not passed to the http attribute. This pull request is changing this behaviour so that the debug parameter is passed down consistently which allows better control for the logging behaviour the http class.

