### PR TITLE
Reset overlay zone is pointing to EIQ, which is wrong

### DIFF
--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -503,7 +503,6 @@ class Tado:
         request = TadoRequest()
         request.command = f"zones/{zone:d}/overlay"
         request.action = Action.RESET
-        request.endpoint = Endpoint.EIQ
         request.mode = Mode.PLAIN
 
         return self.http.request(request)


### PR DESCRIPTION
Propsing a fix to the endpoint, whereas the endpoint is pointing to the EIQ endpoint and not the API endpoint itself.

The first screenshots show the debug breakpoint where the endpoint is wrongfully set to EIQ, whilst the DELETE method is used for the zones/1/overlay command (meaning a reset back to the Smart schedule of Tado itself).
![image](https://github.com/wmalgadey/PyTado/assets/5011203/2ad0764e-9686-46bf-83c8-e7e99aff334c)

Removing this particular line will by default let it use the standard API v2 endpoint.
