### PR TITLE
Add separate CONST_OVERLAY_NEXT_TIME_BLOCK  to use CONST_OVERLAY_TADO_MODE for the actual TADO_MODE 

### DIFF
--- a/PyTado/const.py
+++ b/PyTado/const.py
@@ -23,9 +23,14 @@ CONST_FAN_MIDDLE = "MIDDLE"
 CONST_FAN_HIGH = "HIGH"
 
 # When we change the temperature setting, we need an overlay mode
-CONST_OVERLAY_TADO_MODE = "NEXT_TIME_BLOCK"  # wait until tado changes the mode automatic
+# The tado API distinguishes between type and typeSkillBasedApp
+# There are 3 main types: TADO_MODE, MANUAL, and TIMER
+# The TIMER Type can be used with either typeSkillBasedApp TIMER to wait an also provided time or with NEXT_TIME_BLOCK which automatically sets the time until the next time block for the zone begins
+CONST_OVERLAY_TADO_MODE = "TADO_MODE"  # wait until tado changes the mode automatic (e.g., by next time block or change in home state)
 CONST_OVERLAY_MANUAL = "MANUAL"  # the user has change the temperature or mode manually
 CONST_OVERLAY_TIMER = "TIMER"  # the temperature will be reset after a timespan
+CONST_OVERLAY_NEXT_TIME_BLOCK = "NEXT_TIME_BLOCK"  # set overlay until start of the next time block (ignoring intermediate home state changes)
+
 
 # Heat always comes first since we get the
 # min and max tempatures for the zone from


### PR DESCRIPTION
In the const.py there is no overlay type/mode constant that is set to "TADO_MODE". However, this string is supported by the tado API, and if used as typeSkillBasedApp the overlay will remain until either the next time block is reached or the home state is changed.

At the moment the CONST_OVERLAY_TADO_MODE is set to "NEXT_TIME_BLOK". In contrast to the actual "TADO_MODE," this overlay remains until the time of the next time block arrives independently of the home state.

The two different types are reflected in the UI like this

TADO_MODE
<img width="300" alt="TADO_MODE" src="https://github.com/wmalgadey/PyTado/assets/5639787/cf6a09e6-be0f-41a4-9bea-9d4115327d4e">

NEXT_TIME_BLOCK
<img width="300" alt="NEXT_TIME_BLOCK" src="https://github.com/wmalgadey/PyTado/assets/5639787/2a04b588-da77-4c97-8f89-df0cd28a878f">

Therefore, I'd suggest that CONST_OVERLAY_TADO_MODE is now set to "TADO_MODE" and a new CONST_OVERLAY_NEXT_TIME_BLOCK is introduced. Since this is a breaking change for everyone using the previous definition of CONST_OVERLAY_TADO_MODE, it should be discussed how to proceed. However, using a const named this way might have caused unintended behavior in the past.