### PR TITLE
Fixing Auth cloudfront returning error

### DIFF
--- a/PyTado/http/http.py
+++ b/PyTado/http/http.py
@@ -244,7 +244,7 @@ class Http:
                                         params=data,
                                         timeout=self.timeout,
                                         data=json.dumps({}).encode('utf8'),
-                                        headers=headers=self.request_headers
+                                        headers=self.request_headers
                                         )
         if response.status_code == 400:
             raise TadoWrongCredentialsException("Your username or password is invalid")

--- a/PyTado/http/http.py
+++ b/PyTado/http/http.py
@@ -83,6 +83,14 @@ class Http:
     # Id
     id = 0
 
+    # Request Header Information
+    request_headers = {
+        'Content-Type': 'application/json',
+        'Origin': 'https://app.tado.com',
+        'Referer': 'https://app.tado.com/',
+        'User-Agent' : 'PyTado'
+    }
+
     __username = None
     __password = None
 
@@ -213,10 +221,7 @@ class Http:
             params=data,
             timeout=self.timeout,
             data=json.dumps({}).encode('utf8'),
-            headers={
-                'Content-Type': 'application/json',
-                'Referer': 'https://app.tado.com/'
-            }
+            headers=self.request_headers
         )
 
         self.__set_oauth_header(response.json())
@@ -239,10 +244,7 @@ class Http:
                                         params=data,
                                         timeout=self.timeout,
                                         data=json.dumps({}).encode('utf8'),
-                                        headers={
-                                            'Content-Type': 'application/json',
-                                            'Referer': 'https://app.tado.com/'
-                                        }
+                                        headers=headers=self.request_headers
                                         )
         if response.status_code == 400:
             raise TadoWrongCredentialsException("Your username or password is invalid")


### PR DESCRIPTION
Since this morning, my homeassistant integration failed to connect...

After some digging, I found that CloudFront is returning Error when I try the command
```
>>> from PyTado.interface import Tado
>>> t = Tado('my@username.com', 'mypassword')
>>> climate = t.getClimate(zone=1)
```

Adding the `user Agent` seems to work reliability... This maybe isolated to Amsterdam server they have.. 

> I'm not a Python developer, so I did what I could to make it work..