### PR TITLE
Add tado X support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Author: Chris Jewell <chrism0dwk@gmail.com>
 Modified: Gareth Jeanne <contact@garethjeanne.co.uk>
           Wolfgang Malgadey <w.malgadey@gmail.com>
           Matt Clayton <matt.r.clayton@gmail.com>
+          Karl Beecken <karl@beecken.berlin>

--- a/PyTado/const.py
+++ b/PyTado/const.py
@@ -43,7 +43,7 @@ CONST_HORIZONTAL_SWING_RIGHT = "RIGHT"
 
 # When we change the temperature setting, we need an overlay mode
 CONST_OVERLAY_TADO_MODE = "NEXT_TIME_BLOCK"  # wait until tado changes the mode automatic
-CONST_OVERLAY_MANUAL = "MANUAL"  # the user has change the temperature or mode manually
+CONST_OVERLAY_MANUAL = "MANUAL"  # the user has changed the temperature or mode manually
 CONST_OVERLAY_TIMER = "TIMER"  # the temperature will be reset after a timespan
 
 # Heat always comes first since we get the

--- a/PyTado/exceptions.py
+++ b/PyTado/exceptions.py
@@ -8,6 +8,9 @@ class TadoException(Exception):
 class TadoNotSupportedException(TadoException):
     """Exception to indicate a requested action is not supported by Tado."""
 
+class TadoXNotSupportedException(TadoException):
+    """Exception to indicate a requested action is not supported by the Tado X API."""
+
 
 class TadoCredentialsException(TadoException):
     """Exception to indicate something with credentials"""

--- a/PyTado/http/__init__.py
+++ b/PyTado/http/__init__.py
@@ -1,1 +1,1 @@
-from .http import Action, Domain, Endpoint, Http, Mode, TadoRequest
+from .http import Action, Domain, Endpoint, Http, Mode, TadoRequest, TadoXRequest

--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -7,8 +7,6 @@ import logging
 import warnings
 from enum import IntEnum
 
-from urllib3 import request
-
 from .exceptions import TadoNotSupportedException, TadoXNotSupportedException
 from PyTado.http import Action, Domain, Endpoint, Http, Mode, TadoRequest, TadoXRequest
 from PyTado.logging import Logger

--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -789,6 +789,12 @@ class Tado:
 
         data = self.get_state(zone)
 
+        if self.http.isX:
+            if 'activated'in data['openWindow']:
+                return {'openWindowDetected': True}
+            else:
+                return {'openWindowDetected': False}
+
         if "openWindowDetected" in data:
             return {'openWindowDetected': data['openWindowDetected']}
         else:

--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -7,10 +7,13 @@ import logging
 import warnings
 from enum import IntEnum
 
-from .exceptions import TadoNotSupportedException
-from PyTado.http import Action, Domain, Endpoint, Http, Mode, TadoRequest
+from urllib3 import request
+
+from .exceptions import TadoNotSupportedException, TadoXNotSupportedException
+from PyTado.http import Action, Domain, Endpoint, Http, Mode, TadoRequest, TadoXRequest
 from PyTado.logging import Logger
 from .zone import TadoZone
+from typing import Any
 
 
 class Tado:
@@ -77,10 +80,16 @@ class Tado:
         Gets device information.
         """
 
-        request = TadoRequest()
-        request.command = "devices"
-
-        return self.http.request(request)
+        if self.http.isX:
+            request = TadoXRequest()
+            request.command = "roomsAndDevices"
+            rooms: list[dict[str, Any]] = self.http.request(request)['rooms']
+            devices = [device for room in rooms for device in room['devices']]
+            return devices
+        else:
+            request = TadoRequest()
+            request.command = "devices"
+            return self.http.request(request)
 
     # <editor-fold desc="Deprecated">
     def getZones(self):
@@ -96,10 +105,15 @@ class Tado:
         Gets zones information.
         """
 
-        request = TadoRequest()
-        request.command = "zones"
+        if self.http.isX:
+            request = TadoXRequest()
+            request.command = "roomsAndDevices"
+            return self.http.request(request)['rooms']
+        else:
+            request = TadoRequest()
+            request.command = "zones"
+            return self.http.request(request)
 
-        return self.http.request(request)
 
     # <editor-fold desc="Deprecated">
     def getZoneState(self, zone):
@@ -114,8 +128,10 @@ class Tado:
         """
         Gets current state of Zone as a TadoZone object.
         """
-
-        return TadoZone(self.get_state(zone), zone)
+        if self.http.isX:
+            return self.get_state(zone)
+        else:
+            return TadoZone(self.get_state(zone), zone)
 
     # <editor-fold desc="Deprecated">
     def getZoneStates(self):
@@ -131,8 +147,12 @@ class Tado:
         Gets current states of all zones.
         """
 
-        request = TadoRequest()
-        request.command = "zoneStates"
+        if self.http.isX:
+            request = TadoXRequest()
+            request.command = "rooms"
+        else:
+            request = TadoRequest()
+            request.command = "zoneStates"
 
         return self.http.request(request)
 
@@ -149,10 +169,14 @@ class Tado:
         """
         Gets current state of Zone.
         """
-
-        request = TadoRequest()
-        request.command = f"zones/{zone}/state"
-        data = {**self.http.request(request), **self.get_zone_overlay_default(zone)}
+        if self.http.isX:
+            request = TadoXRequest()
+            request.command = f"rooms/{zone}"
+            data = self.http.request(request)
+        else:
+            request = TadoRequest()
+            request.command = f"zones/{zone}/state"
+            data = {**self.http.request(request), **self.get_zone_overlay_default(zone)}
 
         return data
 
@@ -236,7 +260,10 @@ class Tado:
     def get_capabilities(self, zone):
         """
         Gets current capabilities of zone.
+        TODO: This method is not currently supported by the Tado X API, check if it is needed
         """
+        if self.http.isX:
+            raise TadoXNotSupportedException("This method is not currently supported by the Tado X API")
 
         request = TadoRequest()
         request.command = f"zones/{zone:d}/capabilities"
@@ -258,7 +285,11 @@ class Tado:
         """
 
         data = self.get_state(zone)['sensorDataPoints']
-        return {'temperature': data['insideTemperature']['celsius'],
+        if self.http.isX:
+            return {'temperature': data['insideTemperature']['value'],
+                    'humidity': data['humidity']['percentage']}
+        else:
+            return {'temperature': data['insideTemperature']['celsius'],
                 'humidity': data['humidity']['percentage']}
 
     # <editor-fold desc="Deprecated">
@@ -275,15 +306,21 @@ class Tado:
         Get the Timetable type currently active
         """
 
-        request = TadoRequest()
-        request.command = f"zones/{zone:d}/schedule/activeTimetable"
-        request.mode = Mode.PLAIN
-        data = self.http.request(request)
+        if self.http.isX:
+            # Not currently supported by the Tado X API
+            raise TadoXNotSupportedException("This method is not currently supported by the Tado X API")
+        else:
+            request = TadoRequest()
+            request.command = f"zones/{zone:d}/schedule/activeTimetable"
+            request.mode = Mode.PLAIN
+            data = self.http.request(request)
 
-        if "id" in data:
-            return Tado.Timetable(data["id"])
+            if "id" in data:
+                return Tado.Timetable(data["id"])
 
-        raise Exception(f"Returned data did not contain \"id\" : {str(data)}")
+            raise Exception(f"Returned data did not contain \"id\" : {str(data)}")
+
+
 
     # <editor-fold desc="Deprecated">
     def getHistoric(self, zone, date):
@@ -328,6 +365,10 @@ class Tado:
         id = 3 : SEVEN_DAY (MONDAY, TUESDAY, WEDNESDAY ...)
         """
 
+        if self.http.isX:
+            # Not currently supported by the Tado X API
+            raise TadoXNotSupportedException("This method is not currently supported by the Tado X API")
+
         # Type checking
         if not isinstance(_id, Tado.Timetable):
             raise TypeError('id must be an instance of Tado.Timetable')
@@ -350,12 +391,19 @@ class Tado:
 
     # </editor-fold>
 
-    def get_schedule(self, zone, _id, day=None):
+    def get_schedule(self, zone, _id=None, day=None):
         """
         Get the JSON representation of the schedule for a zone.
         Zone has 3 different schedules, one for each timetable (see setTimetable)
         """
 
+        if self.http.isX:
+            request = TadoXRequest()
+            request.command = f'rooms/{zone}/schedule'
+            return self.http.request(request)
+
+        if not _id:
+            raise ValueError('id must be an instance of Tado.Timetable')
         # Type checking
         if not isinstance(_id, Tado.Timetable):
             raise TypeError('id must be an instance of Tado.Timetable')
@@ -377,14 +425,25 @@ class Tado:
 
     # </editor-fold>
 
-    def set_schedule(self, zone, _id, day, data):
+    def set_schedule(self, zone, data, _id=None, day=None):
         """
-        Set the schedule for a zone, day is required
+        Set the schedule for a zone, day is required for non-X API
         """
+
+        # TODO: sometimes gives back 400 error
+        if self.http.isX:
+            request = TadoXRequest()
+            request.action = Action.SET
+            request.command = f'rooms/{zone}/schedule'
+            request.payload = data
+            request.mode = Mode.OBJECT
+            return self.http.request(request)
 
         # Type checking
         if not isinstance(_id, Tado.Timetable):
             raise TypeError('id must be an instance of Tado.Timetable')
+        if not isinstance(day, int):
+            raise ValueError('day must be an integer')
 
         request = TadoRequest()
         request.command = f"zones/{zone:d}/schedule/timetables/{_id:d}/blocks/{day}"
@@ -427,7 +486,10 @@ class Tado:
         Gets air quality information
         """
 
-        request = TadoRequest()
+        if self.http.isX:
+            request = TadoXRequest()
+        else:
+            request = TadoRequest()
         request.command = "airComfort"
 
         return self.http.request(request)
@@ -460,6 +522,11 @@ class Tado:
         """
         Gets getAppUsersRelativePositions data
         """
+
+        if self.http.isX:
+            # Not currently supported by the Tado X API
+            # TODO: reverse engineer mobile API
+            raise TadoXNotSupportedException("This method is not currently supported by the Tado X API")
 
         request = TadoRequest()
         request.command = "getAppUsersRelativePositions"
@@ -500,12 +567,19 @@ class Tado:
         Delete current overlay
         """
 
-        request = TadoRequest()
-        request.command = f"zones/{zone:d}/overlay"
-        request.action = Action.RESET
-        request.mode = Mode.PLAIN
+        if self.http.isX:
+            request = TadoXRequest()
+            request.command = f"rooms/{zone}/resumeSchedule"
+            request.action = Action.SET
 
-        return self.http.request(request)
+            return self.http.request(request)
+        else:
+            request = TadoRequest()
+            request.command = f"zones/{zone:d}/overlay"
+            request.action = Action.RESET
+            request.mode = Mode.PLAIN
+
+            return self.http.request(request)
 
     # <editor-fold desc="Deprecated">
     def setZoneOverlay(self, zone, overlayMode, setTemp=None, duration=None, deviceType='HEATING', power="ON",
@@ -540,8 +614,23 @@ class Tado:
 
         post_data = {
             "setting": {"type": device_type, "power": power},
-            "termination": {"typeSkillBasedApp": overlay_mode},
+            "termination": {"type": overlay_mode},
         }
+
+        if self.http.isX:
+            if set_temp is not None:
+                post_data["setting"]["temperature"] = {"value": set_temp, "valueRaw": set_temp, "precision": 0.1}
+
+            if duration is not None:
+                post_data["termination"]["durationInSeconds"] = duration
+
+            request = TadoXRequest()
+            request.command = f"rooms/{zone}/manualControl"
+            request.action = Action.SET
+            request.payload = post_data
+
+            return self.http.request(request)
+
 
         if set_temp is not None:
             post_data["setting"]["temperature"] = {"celsius": set_temp}
@@ -583,6 +672,10 @@ class Tado:
         """
         Get current overlay default settings for zone.
         """
+
+        if self.http.isX:
+            # Not currently supported by the Tado X API
+            raise TadoXNotSupportedException("This method is not currently supported by the Tado X API")
 
         request = TadoRequest()
         request.command = f"zones/{zone:d}/defaultOverlay"
@@ -718,6 +811,10 @@ class Tado:
         Note: This can only be set if an open window was detected in this zone
         """
 
+        if sef.http.isX:
+            # Not currently supported by the Tado X API
+            raise TadoXNotSupportedException("This method is not currently supported by the Tado X API")
+
         request = TadoRequest()
         request.command = f"zones/{zone:d}/state/openWindow/activate"
         request.action = Action.SET
@@ -738,6 +835,10 @@ class Tado:
         """
         Sets the window in zone to closed
         """
+
+        if self.http.isX:
+            # TODO test with X
+            raise TadoXNotSupportedException("This method is not currently supported by the Tado X API")
 
         request = TadoRequest()
         request.command = f"zones/{zone:d}/state/openWindow"
@@ -761,6 +862,12 @@ class Tado:
         Gets information about devices
         with option to get specific info i.e. cmd='temperatureOffset'    
         """
+
+        if self.http.isX:
+            # Not currently supported by the Tado X API
+            # Is included in the roomsAndDevices endpoint
+            raise TadoXNotSupportedException("This method is not currently supported by the Tado X API")
+
         request = TadoRequest()
         request.command = cmd
         request.action = Action.GET
@@ -782,6 +889,15 @@ class Tado:
         """
         Set the Temperature offset on the device.
         """
+
+        if self.http.isX:
+            request = TadoXRequest()
+            request.command = f"roomsAndDevices/devices/{device_id}"
+            request.action = Action.UPDATE
+            request.payload = {"temperatureOffset": offset}
+
+            return self.http.request(request)
+
 
         request = TadoRequest()
         request.command = "temperatureOffset"
@@ -914,6 +1030,7 @@ class Tado:
     def get_zone_control(self, zone):
         """
         Get zone control information
+        TODO: Test with X
         """
 
         request = TadoRequest()
@@ -924,6 +1041,7 @@ class Tado:
     def set_zone_heating_circuit(self, zone, heating_circuit):
         """
         Sets the heating circuit for a zone
+        TODO: Test with X
         """
 
         request = TadoRequest()

--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -815,7 +815,7 @@ class Tado:
         Note: This can only be set if an open window was detected in this zone
         """
 
-        if sef.http.isX:
+        if self.http.isX:
             # Not currently supported by the Tado X API
             raise TadoXNotSupportedException("This method is not currently supported by the Tado X API")
 

--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -127,7 +127,7 @@ class Tado:
         Gets current state of Zone as a TadoZone object.
         """
         if self.http.isX:
-            return self.get_state(zone)
+            return TadoZone(self.get_state(zone), zone, isX=True)
         else:
             return TadoZone(self.get_state(zone), zone)
 

--- a/PyTado/zone.py
+++ b/PyTado/zone.py
@@ -401,7 +401,7 @@ class TadoZone:
             
             if "manualControlTermination" in data:
                 if data["manualControlTermination"]:
-                    self._current_hvac_mode = CONST_MODE_HEAT
+                    self._current_hvac_mode = CONST_MODE_HEAT if self._power == "ON" else CONST_MODE_OFF
                     self._overlay_termination_type = data["manualControlTermination"]["type"]
                     self._overlay_termination_timestamp = data["manualControlTermination"]["projectedExpiry"]
                 else:

--- a/PyTado/zone.py
+++ b/PyTado/zone.py
@@ -9,6 +9,7 @@ from .const import (
     CONST_HVAC_IDLE,
     CONST_HVAC_OFF,
     CONST_LINK_OFFLINE,
+    CONST_MODE_HEAT,
     CONST_MODE_OFF,
     CONST_MODE_SMART_SCHEDULE,
     DEFAULT_TADO_PRECISION,
@@ -27,7 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 class TadoZone:
     """Represent a tado zone."""
 
-    def __init__(self, data, zone_id):
+    def __init__(self, data, zone_id, isX: bool = False):
         """Create a tado zone."""
         self._data = data
         self._zone_id = zone_id
@@ -54,7 +55,6 @@ class TadoZone:
         self._heating_power = None
         self._heating_power_percentage = None
         self._tado_mode = None
-        self._overlay_active = None
         self._overlay_termination_type = None
         self._overlay_termination_timestamp = None
         self._preparation = None
@@ -64,6 +64,7 @@ class TadoZone:
         self._precision = DEFAULT_TADO_PRECISION
         self._default_overlay_termination_type = None
         self._default_overlay_termination_duration = None
+        self.isX = isX
         self.update_data(data)
 
     @property
@@ -238,11 +239,13 @@ class TadoZone:
             sensor_data = data["sensorDataPoints"]
 
             if "insideTemperature" in sensor_data:
-                temperature = float(sensor_data["insideTemperature"]["celsius"])
-                self._current_temp = temperature
-                self._current_temp_timestamp = sensor_data["insideTemperature"][
-                    "timestamp"
-                ]
+                if self.isX:
+                    self._current_temp = float(sensor_data["insideTemperature"]["value"])
+                    self._current_temp_timestamp = None
+                else:
+                    temperature = float(sensor_data["insideTemperature"]["celsius"])
+                    self._current_temp = temperature
+                    self._current_temp_timestamp = sensor_data["insideTemperature"]["timestamp"]
                 if "precision" in sensor_data["insideTemperature"]:
                     self._precision = sensor_data["insideTemperature"]["precision"][
                         "celsius"
@@ -251,7 +254,10 @@ class TadoZone:
             if "humidity" in sensor_data:
                 humidity = float(sensor_data["humidity"]["percentage"])
                 self._current_humidity = humidity
-                self._current_humidity_timestamp = sensor_data["humidity"]["timestamp"]
+                if self.isX:
+                    self._current_humidity_timestamp = None
+                else:
+                    self._current_humidity_timestamp = sensor_data["humidity"]["timestamp"]
 
         self._is_away = None
         self._tado_mode = None
@@ -259,9 +265,12 @@ class TadoZone:
             self._is_away = data["tadoMode"] == "AWAY"
             self._tado_mode = data["tadoMode"]
 
+
         self._link = None
         if "link" in data:
             self._link = data["link"]["state"]
+        if "connection" in data:
+            self._link = data["connection"]["state"]
 
         self._current_hvac_action = CONST_HVAC_OFF
 
@@ -271,8 +280,11 @@ class TadoZone:
                 "temperature" in data["setting"]
                 and data["setting"]["temperature"] is not None
             ):
-                setting = float(data["setting"]["temperature"]["celsius"])
-                self._target_temp = setting
+                if self.isX:
+                    self._target_temp = float(data["setting"]["temperature"]["value"])
+                else:
+                    setting = float(data["setting"]["temperature"]["celsius"])
+                    self._target_temp = setting
 
             setting = data["setting"]
 
@@ -378,5 +390,21 @@ class TadoZone:
         if "terminationCondition" in data:
             self._default_overlay_termination_type = data["terminationCondition"].get('type',None)
             self._default_overlay_termination_duration = data["terminationCondition"].get('durationInSeconds',None)
+        
+        if self.isX:
+            if self._power == "ON":
+                self._current_hvac_action = CONST_HVAC_IDLE if data["heatingPower"]["percentage"] == 0 else CONST_HVAC_HEAT
+                self._heating_power_percentage = data["heatingPower"]["percentage"]
+            else:
+                self._heating_power_percentage = 0
+                self._current_hvac_action = CONST_HVAC_OFF
             
-            
+            if "manualControlTermination" in data:
+                if data["manualControlTermination"]:
+                    self._current_hvac_mode = CONST_MODE_HEAT
+                    self._overlay_termination_type = data["manualControlTermination"]["type"]
+                    self._overlay_termination_timestamp = data["manualControlTermination"]["projectedExpiry"]
+                else:
+                    self._overlay_termination_type = None
+                    self._overlay_termination_timestamp = None
+


### PR DESCRIPTION
This adds basic tado X support.

The module auto-detects if it connects to a tado X account and uses other API endpoints if applicable.

Note: the API scheme of tado X differs severely sometimes, so with this patch old applications that want to use tado X may be adapted to also reflect these changes, some endpoints do not work the same way.