### PR TITLE
Fix docs using deprecated method

### DIFF
--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -17,7 +17,7 @@ from typing import Any
 class Tado:
     """Interacts with a Tado thermostat via public API.
     Example usage: t = Tado('me@somewhere.com', 'mypasswd')
-                   t.getClimate(1) # Get climate, zone 1.
+                   t.get_climate(1) # Get climate, zone 1.
     """
 
     class Timetable(IntEnum):

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Example basic usage
 
     >>> from PyTado.interface import Tado
     >>> t = Tado('my@username.com', 'mypassword')
-    >>> climate = t.getClimate(zone=1)
+    >>> climate = t.get_climate(zone=1)
 
 Development
 -----------


### PR DESCRIPTION
Change deprecated method getClimate to the correct get_climate documentation of Tado class in interface.py and the Readme.

Just a really minor annoyance for first time users.