### PR TITLE
adding the minder api from PR !64

### DIFF
--- a/PyTado/http.py
+++ b/PyTado/http.py
@@ -8,6 +8,7 @@ import logging
 import pprint
 from datetime import datetime, timedelta
 from typing import Any
+from urllib.parse import urlencode
 
 import requests
 
@@ -27,6 +28,7 @@ class Endpoint(enum.StrEnum):
     EIQ = "https://energy-insights.tado.com/api/"
     TARIFF = "https://tariff-experience.tado.com/api/"
     GENIE = "https://genie.tado.com/api/v2/"
+    MINDER = "https://minder.tado.com/v1/"
 
 
 class Domain(enum.StrEnum):
@@ -65,6 +67,7 @@ class TadoRequest:
         domain: Domain = Domain.HOME,
         device: int | None = None,
         mode: Mode = Mode.OBJECT,
+        params: dict[str, Any] | None = None,
     ):
         self.endpoint = endpoint
         self.command = command
@@ -73,6 +76,7 @@ class TadoRequest:
         self.domain = domain
         self.device = device
         self.mode = mode
+        self.params = params
 
 
 class TadoXRequest(TadoRequest):
@@ -87,6 +91,7 @@ class TadoXRequest(TadoRequest):
         domain: Domain = Domain.HOME,
         device: int | None = None,
         mode: Mode = Mode.OBJECT,
+        params: dict[str, Any] | None = None,
     ):
         super().__init__(
             endpoint=endpoint,
@@ -96,6 +101,7 @@ class TadoXRequest(TadoRequest):
             domain=domain,
             device=device,
             mode=mode,
+            params=params,
         )
         self._action = action
 
@@ -214,6 +220,8 @@ class Http:
             url = f"{request.endpoint}{request.domain}/{request.device}/{request.command}"
         elif request.domain == Domain.ME:
             url = f"{request.endpoint}{request.domain}"
+        elif request.endpoint == Endpoint.MINDER:
+            url = f"{request.endpoint}{request.domain}/{self.id:d}/{request.command}?{urlencode(request.params)}"
         else:
             url = f"{request.endpoint}{request.domain}/{self._id:d}/{request.command}"
         return url

--- a/PyTado/interface/api/my_tado.py
+++ b/PyTado/interface/api/my_tado.py
@@ -621,3 +621,18 @@ class Tado:
         request.payload = {"circuitNumber": heating_circuit}
 
         return self._http.request(request)
+
+    def get_running_times(
+        self, date=datetime.datetime.now().strftime("%Y-%m-%d")
+    ) -> dict:
+        """
+        Get the running times from the Minder API
+        """
+
+        request = TadoRequest()
+        request.command = "runningTimes"
+        request.action = Action.GET
+        request.endpoint = Endpoint.MINDER
+        request.params = {"from": date}
+
+        return self._http.request(request)

--- a/tests/fixtures/running_times.json
+++ b/tests/fixtures/running_times.json
@@ -1,0 +1,80 @@
+{
+    "lastUpdated": "2023-08-05T19:50:21Z",
+    "runningTimes": [
+        {
+            "endTime": "2023-08-02 00:00:00",
+            "runningTimeInSeconds": 0,
+            "startTime": "2023-08-01 00:00:00",
+            "zones": [
+                {
+                    "id": 1,
+                    "runningTimeInSeconds": 1
+                },
+                {
+                    "id": 2,
+                    "runningTimeInSeconds": 2
+                },
+                {
+                    "id": 3,
+                    "runningTimeInSeconds": 3
+                },
+                {
+                    "id": 4,
+                    "runningTimeInSeconds": 4
+                }
+            ]
+        },
+        {
+            "endTime": "2023-08-03 00:00:00",
+            "runningTimeInSeconds": 0,
+            "startTime": "2023-08-02 00:00:00",
+            "zones": [
+                {
+                    "id": 1,
+                    "runningTimeInSeconds": 5
+                },
+                {
+                    "id": 2,
+                    "runningTimeInSeconds": 6
+                },
+                {
+                    "id": 3,
+                    "runningTimeInSeconds": 7
+                },
+                {
+                    "id": 4,
+                    "runningTimeInSeconds": 8
+                }
+            ]
+        },
+        {
+            "endTime": "2023-08-04 00:00:00",
+            "runningTimeInSeconds": 0,
+            "startTime": "2023-08-03 00:00:00",
+            "zones": [
+                {
+                    "id": 1,
+                    "runningTimeInSeconds": 9
+                },
+                {
+                    "id": 2,
+                    "runningTimeInSeconds": 10
+                },
+                {
+                    "id": 3,
+                    "runningTimeInSeconds": 11
+                },
+                {
+                    "id": 4,
+                    "runningTimeInSeconds": 12
+                }
+            ]
+        }
+    ],
+    "summary": {
+        "endTime": "2023-08-06 00:00:00",
+        "meanInSecondsPerDay": 24,
+        "startTime": "2023-08-01 00:00:00",
+        "totalRunningTimeInSeconds": 120
+    }
+}

--- a/tests/test_my_tado.py
+++ b/tests/test_my_tado.py
@@ -79,3 +79,16 @@ class TadoTestCase(unittest.TestCase):
         with mock.patch("PyTado.http.Http.request"):
             with self.assertRaises(Exception):
                 self.tado_client.set_auto()
+
+    def test_get_running_times(self):
+        """Test the get_running_times method."""
+
+        with mock.patch(
+            "PyTado.http.Http.request",
+            return_value=json.loads(common.load_fixture("running_times.json")),
+        ):
+            running_times = self.tado_client.get_running_times("2023-08-01")
+
+            assert self.tado_client._http.request.called
+            assert running_times["lastUpdated"] == "2023-08-05T19:50:21Z"
+            assert running_times["runningTimes"][0]["zones"][0]["id"] == 1


### PR DESCRIPTION
## Description
from @erwindouna:
> A proposal to add the Minder API to get the running times. My Black linter made more changes than needed. Yet, I didn't found any guidelines or settings. Hope you like it! :)

---

## Related Issues
- https://github.com/wmalgadey/PyTado/pull/64

---

## Type of Changes
Mark the type of changes included in this pull request:

- [ ] Bugfix
- [x] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Other (please specify):

---

## Checklist
- [ ] I have tested the changes locally and they work as expected.
- [ ] I have added/updated necessary documentation (if applicable).
- [ ] I have followed the code style and guidelines of the project.
- [ ] I have searched for and linked any related issues.

---

## Additional Notes
Add any additional comments, screenshots, or context for the reviewer(s).

---

Thank you for your contribution to PyTado! 🎉
