### PR TITLE
Support devices with serialNumber as their property

### DIFF
--- a/PyTado/interface/api/hops_tado.py
+++ b/PyTado/interface/api/hops_tado.py
@@ -72,9 +72,13 @@ class TadoX(Tado):
         devices = [device for room in rooms for device in room["devices"]]
 
         for device in devices:
+            serial_number = device.get("serialNo", device.get("serialNumber"))
+            if not serial_number:
+                continue
+            
             request = TadoXRequest()
             request.domain = Domain.DEVICES
-            request.device = device["serialNo"]
+            request.device = serial_number
             device.update(self._http.request(request))
 
         if "otherDevices" in rooms_and_devices:

--- a/PyTado/interface/api/hops_tado.py
+++ b/PyTado/interface/api/hops_tado.py
@@ -75,7 +75,7 @@ class TadoX(Tado):
             serial_number = device.get("serialNo", device.get("serialNumber"))
             if not serial_number:
                 continue
-            
+
             request = TadoXRequest()
             request.domain = Domain.DEVICES
             request.device = serial_number

--- a/tests/fixtures/tadox/rooms_and_devices.json
+++ b/tests/fixtures/tadox/rooms_and_devices.json
@@ -31,7 +31,7 @@
           }
         ],
         "roomId": 1,
-        "roomName": "Room 1 ",
+        "roomName": "Room 1",
         "zoneControllerAssignable": false,
         "zoneControllers": []
       },

--- a/tests/fixtures/tadox/rooms_and_devices.json
+++ b/tests/fixtures/tadox/rooms_and_devices.json
@@ -1,0 +1,64 @@
+{
+    "otherDevices": [
+      {
+        "connection": {
+          "state": "CONNECTED"
+        },
+        "firmwareVersion": "245.1",
+        "serialNumber": "IB1234567890",
+        "type": "IB02"
+      }
+    ],
+    "rooms": [
+      {
+        "deviceManualControlTermination": {
+          "durationInSeconds": null,
+          "type": "MANUAL"
+        },
+        "devices": [
+          {
+            "batteryState": "NORMAL",
+            "childLockEnabled": false,
+            "connection": {
+              "state": "CONNECTED"
+            },
+            "firmwareVersion": "243.1",
+            "mountingState": "CALIBRATED",
+            "serialNumber": "VA1234567890",
+            "temperatureAsMeasured": 17.00,
+            "temperatureOffset": 0.0,
+            "type": "VA04"
+          }
+        ],
+        "roomId": 1,
+        "roomName": "Room 1 ",
+        "zoneControllerAssignable": false,
+        "zoneControllers": []
+      },
+      {
+        "deviceManualControlTermination": {
+          "durationInSeconds": null,
+          "type": "MANUAL"
+        },
+        "devices": [
+          {
+            "batteryState": "NORMAL",
+            "childLockEnabled": false,
+            "connection": {
+              "state": "CONNECTED"
+            },
+            "firmwareVersion": "243.1",
+            "mountingState": "CALIBRATED",
+            "serialNumber": "VA1234567891",
+            "temperatureAsMeasured": 18.00,
+            "temperatureOffset": 0.0,
+            "type": "VA04"
+          }
+        ],
+        "roomId": 2,
+        "roomName": " Room 2",
+        "zoneControllerAssignable": false,
+        "zoneControllers": []
+      }
+    ]
+  }


### PR DESCRIPTION
## Description

When I try and use the library to fetch data from my account I noticed the devices have the `serialNo` property as `serialNumber`. This change adds support for that and skips over devices that dont match either. Perhaps it'll be better to raise in such case?

I only have Tado X within my account so perhaps it's related to that?

## Related Issues
Link any related issues that this pull request resolves or is associated with:

**Example:**
- Closes #123
- Related to #456

---

## Type of Changes
Mark the type of changes included in this pull request:

- [x] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Other (please specify):

---

## Checklist
- [ ] I have tested the changes locally and they work as expected.
- [ ] I have added/updated necessary documentation (if applicable).
- [ ] I have followed the code style and guidelines of the project.
- [ ] I have searched for and linked any related issues.

---

## Additional Notes

---

Thank you for your contribution to PyTado! 🎉
