### PR TITLE
Tidy pre-commit config + setup CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches-ignore:
+      - master
+  pull_request: ~
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e '.[all]'
+
+    - name: Run pre-commit hooks
+      uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,13 +31,6 @@ repos:
   hooks:
     - id: pyupgrade
 
-- repo: https://github.com/psf/black
-  rev: 24.10.0
-  hooks:
-    - id: black
-      exclude: tests/
-      args: [--line-length=100]
-
 - repo: https://github.com/PyCQA/flake8
   rev: 7.1.1
   hooks:
@@ -61,7 +54,7 @@ repos:
       args: [--line-length=100, --fix]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.13.0
+  rev: v1.14.0
   hooks:
     - id: mypy
       exclude: tests/


### PR DESCRIPTION
## Description

- Removed redundant black pre-commit hook as ruff is a drop-in replacement and is already there
- Add dedicated pipeline that skips master (due to master push protection in pre-commit config)
- Bump mypy version

---

## Related Issues
Link any related issues that this pull request resolves or is associated with:

**Example:**
- Closes #123
- Related to #456

---

## Type of Changes
Mark the type of changes included in this pull request:

- [ ] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [x] Refactor
- [ ] Other (please specify):

---

## Checklist
- [ ] I have tested the changes locally and they work as expected.
- [ ] I have added/updated necessary documentation (if applicable).
- [ ] I have followed the code style and guidelines of the project.
- [ ] I have searched for and linked any related issues.

---

## Additional Notes
Add any additional comments, screenshots, or context for the reviewer(s).

---

Thank you for your contribution to PyTado! 🎉
