### PR TITLE
add home by bridge api to my tado

### DIFF
--- a/PyTado/http.py
+++ b/PyTado/http.py
@@ -164,12 +164,18 @@ class Http:
         og_request_url = response.request.url
         og_request_headers = response.request.headers
         response_status = response.status_code
+
+        if response.text is None or response.text == "":
+            response_data = {}
+        else:
+            response_data = response.json()
+
         _LOGGER.debug(
             f"\nRequest:\n\tMethod:{og_request_method}"
             f"\n\tURL: {og_request_url}"
             f"\n\tHeaders: {pprint.pformat(og_request_headers)}"
             f"\nResponse:\n\tStatusCode: {response_status}"
-            f"\n\tData: {response.json()}"
+            f"\n\tData: {response_data}"
         )
 
     def request(self, request: TadoRequest) -> dict[str, Any]:

--- a/PyTado/http.py
+++ b/PyTado/http.py
@@ -37,6 +37,7 @@ class Domain(enum.StrEnum):
     HOME = "homes"
     DEVICES = "devices"
     ME = "me"
+    HOME_BY_BRIDGE = "homeByBridge"
 
 
 class Action(enum.StrEnum):
@@ -65,7 +66,7 @@ class TadoRequest:
         action: Action | str = Action.GET,
         payload: dict[str, Any] | None = None,
         domain: Domain = Domain.HOME,
-        device: int | None = None,
+        device: int | str | None = None,
         mode: Mode = Mode.OBJECT,
         params: dict[str, Any] | None = None,
     ) -> None:
@@ -89,7 +90,7 @@ class TadoXRequest(TadoRequest):
         action: Action | str = Action.GET,
         payload: dict[str, Any] | None = None,
         domain: Domain = Domain.HOME,
-        device: int | None = None,
+        device: int | str | None = None,
         mode: Mode = Mode.OBJECT,
         params: dict[str, Any] | None = None,
     ) -> None:
@@ -213,7 +214,7 @@ class Http:
     def _configure_url(self, request: TadoRequest) -> str:
         if request.endpoint == Endpoint.MOBILE:
             url = f"{request.endpoint}{request.command}"
-        elif request.domain == Domain.DEVICES:
+        elif request.domain == Domain.DEVICES or request.domain == Domain.HOME_BY_BRIDGE:
             url = f"{request.endpoint}{request.domain}/{request.device}/{request.command}"
         elif request.domain == Domain.ME:
             url = f"{request.endpoint}{request.domain}"

--- a/PyTado/interface/api/my_tado.py
+++ b/PyTado/interface/api/my_tado.py
@@ -636,7 +636,7 @@ class Tado:
         return self._http.request(request)
 
     def set_boiler_max_output_temperature(
-        self, bridge_id: str, auth_key: str, temperature_in_celcius: int
+        self, bridge_id: str, auth_key: str, temperature_in_celcius: float
     ):
         """
         Set the boiler max output temperature with home by bridge endpoint

--- a/PyTado/interface/api/my_tado.py
+++ b/PyTado/interface/api/my_tado.py
@@ -606,3 +606,33 @@ class Tado:
         request.params = {"from": date}
 
         return self._http.request(request)
+
+    def get_boiler_output_temperature(self, bridge_id: str):
+        """
+        Get the bridge details
+        """
+
+        request = TadoRequest()
+        request.action = Action.GET
+        request.domain = Domain.HOME_BY_BRIDGE
+        request.device = bridge_id
+
+        request.command = "boilerWiringInstallationState"
+        install_state = self._http.request(request)
+
+        return {
+            "boiler": install_state["boiler"],
+        }
+
+    def get_boiler_max_output_temperature(self, bridge_id: str):
+        """
+        Get the bridge details
+        """
+
+        request = TadoRequest()
+        request.action = Action.GET
+        request.domain = Domain.HOME_BY_BRIDGE
+        request.device = bridge_id
+        request.command = "boilerMaxOutputTemperature"
+
+        return self._http.request(request)

--- a/PyTado/interface/api/my_tado.py
+++ b/PyTado/interface/api/my_tado.py
@@ -607,26 +607,23 @@ class Tado:
 
         return self._http.request(request)
 
-    def get_boiler_output_temperature(self, bridge_id: str):
+    def get_boiler_install_state(self, bridge_id: str, auth_key: str):
         """
-        Get the bridge details
+        Get the boiler wiring installation state from home by bridge endpoint
         """
 
         request = TadoRequest()
         request.action = Action.GET
         request.domain = Domain.HOME_BY_BRIDGE
         request.device = bridge_id
-
         request.command = "boilerWiringInstallationState"
-        install_state = self._http.request(request)
+        request.params = {"authKey": auth_key}
 
-        return {
-            "boiler": install_state["boiler"],
-        }
+        return self._http.request(request)
 
-    def get_boiler_max_output_temperature(self, bridge_id: str):
+    def get_boiler_max_output_temperature(self, bridge_id: str, auth_key: str):
         """
-        Get the bridge details
+        Get the boiler max output temperature from home by bridge endpoint
         """
 
         request = TadoRequest()
@@ -634,5 +631,6 @@ class Tado:
         request.domain = Domain.HOME_BY_BRIDGE
         request.device = bridge_id
         request.command = "boilerMaxOutputTemperature"
+        request.params = {"authKey": auth_key}
 
         return self._http.request(request)

--- a/PyTado/interface/api/my_tado.py
+++ b/PyTado/interface/api/my_tado.py
@@ -634,3 +634,20 @@ class Tado:
         request.params = {"authKey": auth_key}
 
         return self._http.request(request)
+
+    def set_boiler_max_output_temperature(
+        self, bridge_id: str, auth_key: str, temperature_in_celcius: int
+    ):
+        """
+        Set the boiler max output temperature with home by bridge endpoint
+        """
+
+        request = TadoRequest()
+        request.action = Action.CHANGE
+        request.domain = Domain.HOME_BY_BRIDGE
+        request.device = bridge_id
+        request.command = "boilerMaxOutputTemperature"
+        request.params = {"authKey": auth_key}
+        request.payload = {"boilerMaxOutputTemperatureInCelsius": temperature_in_celcius}
+
+        return self._http.request(request)

--- a/tests/fixtures/home_by_bridge.boiler_max_output_temperature.json
+++ b/tests/fixtures/home_by_bridge.boiler_max_output_temperature.json
@@ -1,0 +1,1 @@
+{"boilerMaxOutputTemperatureInCelsius":50}

--- a/tests/fixtures/home_by_bridge.boiler_wiring_installation_state.json
+++ b/tests/fixtures/home_by_bridge.boiler_wiring_installation_state.json
@@ -1,0 +1,18 @@
+{
+    "state": "INSTALLATION_COMPLETED",
+    "deviceWiredToBoiler": {
+        "type": "RU02B",
+        "serialNo": "RUXXXXXXXXXX",
+        "thermInterfaceType": "OPENTHERM",
+        "connected": true,
+        "lastRequestTimestamp": "2024-12-28T10:36:47.533Z"
+    },
+    "bridgeConnected": true,
+    "hotWaterZonePresent": false,
+    "boiler": {
+        "outputTemperature": {
+            "celsius": 38.01,
+            "timestamp": "2024-12-28T10:36:54.000Z"
+        }
+    }
+}

--- a/tests/test_my_tado.py
+++ b/tests/test_my_tado.py
@@ -15,9 +15,7 @@ class TadoTestCase(unittest.TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        login_patch = mock.patch(
-            "PyTado.http.Http._login", return_value=(1, "foo")
-        )
+        login_patch = mock.patch("PyTado.http.Http._login", return_value=(1, "foo"))
         get_me_patch = mock.patch("PyTado.interface.api.Tado.get_me")
         login_patch.start()
         get_me_patch.start()
@@ -35,9 +33,7 @@ class TadoTestCase(unittest.TestCase):
         with mock.patch(
             "PyTado.http.Http.request",
             return_value=json.loads(
-                common.load_fixture(
-                    "tadov2.home_state.auto_supported.manual_mode.json"
-                )
+                common.load_fixture("tadov2.home_state.auto_supported.manual_mode.json")
             ),
         ):
             self.tado_client.get_home_state()
@@ -53,9 +49,7 @@ class TadoTestCase(unittest.TestCase):
         with mock.patch(
             "PyTado.http.Http.request",
             return_value=json.loads(
-                common.load_fixture(
-                    "tadov2.home_state.auto_supported.auto_mode.json"
-                )
+                common.load_fixture("tadov2.home_state.auto_supported.auto_mode.json")
             ),
         ):
             self.tado_client.get_home_state()
@@ -92,3 +86,27 @@ class TadoTestCase(unittest.TestCase):
             assert self.tado_client._http.request.called
             assert running_times["lastUpdated"] == "2023-08-05T19:50:21Z"
             assert running_times["runningTimes"][0]["zones"][0]["id"] == 1
+
+    def test_get_boiler_output_temperature(self):
+        with mock.patch(
+            "PyTado.http.Http.request",
+            return_value=json.loads(
+                common.load_fixture("home_by_bridge.boiler_wiring_installation_state.json")
+            ),
+        ):
+            boiler_temperature = self.tado_client.get_boiler_output_temperature("IB123456789")
+
+            assert self.tado_client._http.request.called
+            assert boiler_temperature["boiler"]["outputTemperature"]["celsius"] == 38.01
+
+    def test_get_boiler_max_output_temperature(self):
+        with mock.patch(
+            "PyTado.http.Http.request",
+            return_value=json.loads(
+                common.load_fixture("home_by_bridge.boiler_max_output_temperature.json")
+            ),
+        ):
+            boiler_temperature = self.tado_client.get_boiler_max_output_temperature("IB123456789")
+
+            assert self.tado_client._http.request.called
+            assert boiler_temperature["boilerMaxOutputTemperatureInCelsius"] == 50.0

--- a/tests/test_my_tado.py
+++ b/tests/test_my_tado.py
@@ -87,14 +87,16 @@ class TadoTestCase(unittest.TestCase):
             assert running_times["lastUpdated"] == "2023-08-05T19:50:21Z"
             assert running_times["runningTimes"][0]["zones"][0]["id"] == 1
 
-    def test_get_boiler_output_temperature(self):
+    def test_get_boiler_install_state(self):
         with mock.patch(
             "PyTado.http.Http.request",
             return_value=json.loads(
                 common.load_fixture("home_by_bridge.boiler_wiring_installation_state.json")
             ),
         ):
-            boiler_temperature = self.tado_client.get_boiler_output_temperature("IB123456789")
+            boiler_temperature = self.tado_client.get_boiler_install_state(
+                "IB123456789", "authcode"
+            )
 
             assert self.tado_client._http.request.called
             assert boiler_temperature["boiler"]["outputTemperature"]["celsius"] == 38.01
@@ -106,7 +108,9 @@ class TadoTestCase(unittest.TestCase):
                 common.load_fixture("home_by_bridge.boiler_max_output_temperature.json")
             ),
         ):
-            boiler_temperature = self.tado_client.get_boiler_max_output_temperature("IB123456789")
+            boiler_temperature = self.tado_client.get_boiler_max_output_temperature(
+                "IB123456789", "authcode"
+            )
 
             assert self.tado_client._http.request.called
             assert boiler_temperature["boilerMaxOutputTemperatureInCelsius"] == 50.0

--- a/tests/test_my_tado.py
+++ b/tests/test_my_tado.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 from . import common
 
-from PyTado.http import Http
+from PyTado.http import Http, TadoRequest
 from PyTado.interface.api import Tado
 
 
@@ -80,10 +80,11 @@ class TadoTestCase(unittest.TestCase):
         with mock.patch(
             "PyTado.http.Http.request",
             return_value=json.loads(common.load_fixture("running_times.json")),
-        ):
+        ) as mock_request:
             running_times = self.tado_client.get_running_times("2023-08-01")
 
-            assert self.tado_client._http.request.called
+            mock_request.assert_called_once()
+
             assert running_times["lastUpdated"] == "2023-08-05T19:50:21Z"
             assert running_times["runningTimes"][0]["zones"][0]["id"] == 1
 
@@ -93,12 +94,13 @@ class TadoTestCase(unittest.TestCase):
             return_value=json.loads(
                 common.load_fixture("home_by_bridge.boiler_wiring_installation_state.json")
             ),
-        ):
+        ) as mock_request:
             boiler_temperature = self.tado_client.get_boiler_install_state(
                 "IB123456789", "authcode"
             )
 
-            assert self.tado_client._http.request.called
+            mock_request.assert_called_once()
+
             assert boiler_temperature["boiler"]["outputTemperature"]["celsius"] == 38.01
 
     def test_get_boiler_max_output_temperature(self):
@@ -107,10 +109,31 @@ class TadoTestCase(unittest.TestCase):
             return_value=json.loads(
                 common.load_fixture("home_by_bridge.boiler_max_output_temperature.json")
             ),
-        ):
+        ) as mock_request:
             boiler_temperature = self.tado_client.get_boiler_max_output_temperature(
                 "IB123456789", "authcode"
             )
 
-            assert self.tado_client._http.request.called
+            mock_request.assert_called_once()
+
             assert boiler_temperature["boilerMaxOutputTemperatureInCelsius"] == 50.0
+
+    def test_set_boiler_max_output_temperature(self):
+        with mock.patch(
+            "PyTado.http.Http.request",
+            return_value={"success": True},
+        ) as mock_request:
+            response = self.tado_client.set_boiler_max_output_temperature(
+                "IB123456789", "authcode", 75
+            )
+
+            mock_request.assert_called_once()
+            args, _ = mock_request.call_args
+            request: TadoRequest = args[0]
+
+            self.assertEqual(request.command, "boilerMaxOutputTemperature")
+            self.assertEqual(request.action, "PUT")
+            self.assertEqual(request.payload, {"boilerMaxOutputTemperatureInCelsius": 75})
+
+            # Verify the response
+            self.assertTrue(response["success"])


### PR DESCRIPTION
## Description
Added the requests to `homeByBridge` endpoint of my.tado.com API and included tests.

Some changes are not related to this feature, but I changed it too, because it iritated me while testing:
- simplified and removed duplicated code in `http.py::_configure_url`
- added logging to all http requests. Logging was not implemented for general requests... why?

---

## Related Issues
- Closes #131 

---

## Type of Changes
Mark the type of changes included in this pull request:

- [ ] Bugfix
- [x] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Other (please specify):

---

## Checklist
- [x] I have tested the changes locally and they work as expected.
- [ ] I have added/updated necessary documentation (if applicable).
- [x] I have followed the code style and guidelines of the project.
- [x] I have searched for and linked any related issues.

---

## Additional Notes
Add any additional comments, screenshots, or context for the reviewer(s).

---

Thank you for your contribution to PyTado! 🎉
