### PR TITLE
fix for autopep8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,8 +26,8 @@ repos:
       exclude: tests/
       args: ["--profile", "black"]
 
-- repo: https://github.com/pre-commit/mirrors-autopep8
-  rev: v2.0.4
+- repo: https://github.com/hhatto/autopep8
+  rev: v2.3.1
   hooks:
     - id: autopep8
       exclude: tests/


### PR DESCRIPTION
## Description
the previously used autopep8 repository (https://github.com/pre-commit/mirrors-autopep8) was deprecated and the older version caused some weird bugs when running locally. Changed autopep8 version to 2.3.1 from 2.0.4 and repository to https://github.com/hhatto/autopep8

---

## Type of Changes
Mark the type of changes included in this pull request:

- [x] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Other (please specify):

---

## Checklist
- [x] I have tested the changes locally and they work as expected.
- [ ] I have added/updated necessary documentation (if applicable).
- [ ] I have followed the code style and guidelines of the project.
- [ ] I have searched for and linked any related issues.

---

## Additional Notes
Add any additional comments, screenshots, or context for the reviewer(s).

---

Thank you for your contribution to PyTado! 🎉
