### PR TITLE
Fixed devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -61,10 +61,8 @@
     "name": "PyTado",
     "postCreateCommand": "python3 -m venv venv && . venv/bin/activate && pip install --upgrade pip && pip install -e '.[all]' && pre-commit install",
     "updateContentCommand": "python3 -m venv venv && . venv/bin/activate && pip install --upgrade pip && pip install -e '.[all]' && pre-commit install",
-    "runArgs": [
-        "--userns=keep-id"
-    ],
     "containerUser": "vscode",
+    "remoteUser": "vscode",
     "updateRemoteUserUID": true,
     "containerEnv": {
         "HOME": "/home/vscode"


### PR DESCRIPTION
## Description
I modified the devcontainer to be used with rootless podman. This will break default docker dev environments.

- removed `--userns` parameter
- added `remoteUser` and `containerUser` 

---

## Related Issues
- relates to #133 

---

## Type of Changes
Mark the type of changes included in this pull request:

- [ ] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [x] Other (please specify):
      - dev environment
  
---

## Checklist
- [x] I have tested the changes locally and they work as expected.
- [ ] I have added/updated necessary documentation (if applicable).
- [ ] I have followed the code style and guidelines of the project.
- [ ] I have searched for and linked any related issues.

---

## Additional Notes
Add any additional comments, screenshots, or context for the reviewer(s).

---

Thank you for your contribution to PyTado! 🎉
