### PR TITLE
Fix script naming

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ all = [
 ]
 
 [project.scripts]
-pytado = "pytado.__main__:main"
+pytado = "PyTado.__main__:main"
 
 [tool.setuptools]
 platforms = ["any"]


### PR DESCRIPTION
## Description

Project namespace is `PyTado` which in the current configuration is failing on Linux when trying to invoke it from an installed package. I guess on all case sensitive file systems i will be the same.

---

## Related Issues
Link any related issues that this pull request resolves or is associated with: N/A
 

---

## Type of Changes
Mark the type of changes included in this pull request:

- [x] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Other (please specify):

---

## Checklist
- [ ] I have tested the changes locally and they work as expected.
- [ ] I have added/updated necessary documentation (if applicable).
- [ ] I have followed the code style and guidelines of the project.
- [ ] I have searched for and linked any related issues.

---

## Additional Notes

Tested configuration by installing dist with pipx

```
❯ pipx install code/python/PyTado/dist/python_tado-0.18.5.tar.gz  --force
Installing to existing venv 'python-tado'
  installed package python-tado 0.18.5, installed using Python 3.13.1
  These apps are now globally available
    - pytado
done! ✨ 🌟 ✨

~ 
❯ pytado 
usage: pytado [-h] --email EMAIL --password PASSWORD [--loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}] {get_me,get_state,get_states,get_capabilities} ...
pytado: error: the following arguments are required: --email, --password

```



---

Thank you for your contribution to PyTado! 🎉
