### PR TITLE
fixed error in http with wrong token

### DIFF
--- a/PyTado/http.py
+++ b/PyTado/http.py
@@ -189,9 +189,10 @@ class Http:
         self._x_api: bool | None = None
         self._token_file_path = token_file_path
 
-        if saved_refresh_token or self._load_token():
-            if self._refresh_token(refresh_token=saved_refresh_token, force_refresh=True):
-                self._device_ready()
+        if (saved_refresh_token or self._load_token()) and self._refresh_token(
+            refresh_token=saved_refresh_token, force_refresh=True
+        ):
+            self._device_ready()
         else:
             self._device_activation_status = self._login_device_flow()
 


### PR DESCRIPTION
## Description
Fixed an issue, where we get stuck with no authentication, if the saved refresh token is invalid.

---

## Related Issues
- None

---

## Type of Changes
Mark the type of changes included in this pull request:

- [x] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Other (please specify):

---

## Checklist
- [ ] I have tested the changes locally and they work as expected.
- [ ] I have added/updated necessary documentation (if applicable).
- [ ] I have followed the code style and guidelines of the project.
- [ ] I have searched for and linked any related issues.

---

## Additional Notes
Add any additional comments, screenshots, or context for the reviewer(s).

---

Thank you for your contribution to PyTado! 🎉
