### PR TITLE
Fix devices request in Tado X for 0.18.x

### DIFF
--- a/PyTado/interface/api/hops_tado.py
+++ b/PyTado/interface/api/hops_tado.py
@@ -62,7 +62,7 @@ class TadoX(Tado):
         for device in devices:
             request = TadoXRequest()
             request.domain = Domain.DEVICES
-            request.device = device["serialNo"]
+            request.device = device["serialNumber"]
             device.update(self._http.request(request))
 
         if "otherDevices" in rooms_and_devices:


### PR DESCRIPTION
## Description
in Tado X, the serial number is in the `serialNumber` field, `shortSerialNo` was the field in Tado V3. This breaks API interaction with Tado X setups, because the `serialNo` field doesn't exist

---

## Related Issues
none

---

## Type of Changes
Mark the type of changes included in this pull request:

- [x] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Other (please specify):

---

## Checklist
- [x] I have tested the changes locally and they work as expected.
- [x] I have added/updated necessary documentation (if applicable).
- [x] I have followed the code style and guidelines of the project.
- [x] I have searched for and linked any related issues.

---

## Additional Notes
Would be awesome if this could be merged soon, it is a requirement to make the temporary fix for the Tado X HA integration work again with the new OAuth flow.

---

Thank you for your contribution to PyTado! 🎉
