### PR TITLE
Bump pre-commit dependencies, tidy config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,27 +14,26 @@ repos:
     - id: check-yaml
     - id: check-json
     - id: end-of-file-fixer
-      exclude: custom_components/econnect_metronet/manifest.json
     - id: mixed-line-ending
     - id: trailing-whitespace
 
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.13.2
+  rev: 6.0.1
   hooks:
     - id: isort
       exclude: tests/
       args: ["--profile", "black"]
 
 - repo: https://github.com/hhatto/autopep8
-  rev: v2.3.1
+  rev: v2.3.2
   hooks:
     - id: autopep8
       exclude: tests/
       args: [--max-line-length=100, --in-place, --aggressive]
 
 - repo: https://github.com/PyCQA/flake8
-  rev: 7.1.1
+  rev: 7.2.0
   hooks:
     - id: flake8
       exclude: tests/
@@ -46,22 +45,21 @@ repos:
     - id: pyupgrade
 
 - repo: https://github.com/PyCQA/bandit
-  rev: '1.8.0'
+  rev: '1.8.3'
   hooks:
     - id: bandit
       args: ["-c", "pyproject.toml"]
       additional_dependencies: ["bandit[toml]"]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.8.4
+  rev: v0.11.3
   hooks:
     - id: ruff
       exclude: tests/
       args: [--line-length=100, --fix]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.14.0
+  rev: v1.15.0
   hooks:
     - id: mypy
       exclude: tests/


### PR DESCRIPTION
## Description

- Bump pre-commit dependencies with `pre-commit autoupdate`
  - in theory can be managed with [renovate](https://docs.renovatebot.com/modules/manager/pre-commit/), will try it out on another repo
- Tidy pre-commit config

---

## Related Issues
Link any related issues that this pull request resolves or is associated with:

**Example:**
- Closes #123
- Related to #456

---

## Type of Changes
Mark the type of changes included in this pull request:

- [ ] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [x] Other (please specify): Dev dependency upgrade

---

## Checklist
- [x] I have tested the changes locally and they work as expected.
- [x] I have added/updated necessary documentation (if applicable).
- [x] I have followed the code style and guidelines of the project.
- [x] I have searched for and linked any related issues.

---

## Additional Notes
Add any additional comments, screenshots, or context for the reviewer(s).

---

Thank you for your contribution to PyTado! 🎉
