### PR TITLE
Correct Python devcontainer version to 3.13

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,7 +57,7 @@
             "installTools": false
         }
     },
-    "image": "mcr.microsoft.com/vscode/devcontainers/python:3.12",
+    "image": "mcr.microsoft.com/vscode/devcontainers/python:3.13",
     "name": "PyTado",
     "postStartCommand": "bash scripts/bootstrap",
     "updateContentCommand": "bash scripts/bootstrap",


### PR DESCRIPTION
## Description

Fix devcontainer python version for 3.13 to be consistent.

To resolve this another way we could leverage a tool such as mise but that'll be more involved  (another PR to figure that out) and we don't change versions so often.

## Related Issues
- relates to #193
- relates to #200 
---

## Type of Changes
Mark the type of changes included in this pull request:

- [ ] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Other (please specify):

---

## Checklist
- [ ] I have tested the changes locally and they work as expected.
- [ ] I have added/updated necessary documentation (if applicable).
- [ ] I have followed the code style and guidelines of the project.
- [ ] I have searched for and linked any related issues.

---

## Additional Notes
Add any additional comments, screenshots, or context for the reviewer(s).

---

Thank you for your contribution to PyTado! 🎉
