### PR TITLE
Set customizable user-agent header

### DIFF
--- a/PyTado/__init__.py
+++ b/PyTado/__init__.py
@@ -1,0 +1,6 @@
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("python-tado")
+except PackageNotFoundError:
+    __version__ = "test"  # happens when running as pre-commit hook

--- a/PyTado/http.py
+++ b/PyTado/http.py
@@ -17,6 +17,7 @@ from urllib.parse import urlencode
 
 import requests
 
+from PyTado import __version__
 from PyTado.const import CLIENT_ID_DEVICE
 from PyTado.exceptions import TadoException, TadoWrongCredentialsException
 from PyTado.logger import Logger
@@ -152,6 +153,7 @@ class Http:
         saved_refresh_token: str | None = None,
         http_session: requests.Session | None = None,
         debug: bool = False,
+        user_agent: str | None = None
     ) -> None:
         """
         Initialize the HTTP client for interacting with the Tado API.
@@ -164,6 +166,8 @@ class Http:
             http_session (requests.Session | None): An optional pre-configured HTTP session.
                 If None, a new session will be created.
             debug (bool): If True, enables debug logging. Defaults to False.
+            user_agent (str | None): Optional user-agent header to use for the HTTP requests.
+                If None, a default user-agent PyTado/<PyTado-version> will be used.
 
         Returns:
             None
@@ -177,7 +181,8 @@ class Http:
         self._refresh_at = datetime.now(timezone.utc) + timedelta(minutes=10)
         self._session = http_session or self._create_session()
         self._session.hooks["response"].append(self._log_response)
-        self._headers = {"Referer": "https://app.tado.com/"}
+        self._headers = {"Referer": "https://app.tado.com/",
+                         "user-agent": user_agent or f"PyTado/{__version__}"}
 
         self._user_code: str | None = None
         self._device_verification_url: str | None = None

--- a/PyTado/interface/api/my_tado.py
+++ b/PyTado/interface/api/my_tado.py
@@ -525,7 +525,7 @@ class Tado:
         request.endpoint = Endpoint.EIQ
 
         return self._http.request(request)
-        
+
     def get_eiq_consumption_overview(self, date=datetime.datetime.now().strftime("%Y-%m")):
         """
         Get consumption overview data for a specific month

--- a/PyTado/interface/interface.py
+++ b/PyTado/interface/interface.py
@@ -55,6 +55,7 @@ class Tado:
         saved_refresh_token: str | None = None,
         http_session: requests.Session | None = None,
         debug: bool = False,
+        user_agent: str | None = None,
     ):
         """
         Initializes the interface class.
@@ -67,6 +68,8 @@ class Tado:
             http_session (requests.Session | None, optional): An optional HTTP session to use for
                 requests (can be used in unit tests). Defaults to None.
             debug (bool, optional): Flag to enable or disable debug mode. Defaults to False.
+            user_agent (str | None): Optional user-agent header to use for the HTTP requests.
+                If None, a default user-agent PyTado/<PyTado-version> will be used.
         """
 
         self._http = Http(
@@ -74,6 +77,7 @@ class Tado:
             saved_refresh_token=saved_refresh_token,
             http_session=http_session,
             debug=debug,
+            user_agent=user_agent,
         )
         self._api: API.Tado | API.TadoX | None = None
         self._debug = debug

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -124,6 +124,27 @@ class TestHttp(unittest.TestCase):
         self.assertEqual(instance._id, 1234)
         self.assertEqual(instance.is_x_line, True)
 
+        @responses.activate
+        def test_user_agent(self):
+            """Test that the we set the correct user-agent."""
+            responses.replace(
+                responses.GET,
+                "https://my.tado.com/api/v2/homes/1234/",
+                json=json.loads(
+                    common.load_fixture(
+                        "home_1234/tadov2.my_api_v2_home_state.json"
+                    )
+                ),
+                match=[matchers.header_matcher({"user-agent": "MyCustomAgent/1.0"})],
+                status=200,
+            )
+
+            instance = Http(debug=True, user_agent="MyCustomAgent/1.0")
+            instance.device_activation()
+
+            # Verify that the login was successful
+            self.assertEqual(instance._id, 1234)
+
     @responses.activate
     def test_refresh_token_success(self):
         """Test that the refresh token is successfully updated."""

--- a/tests/test_my_tado.py
+++ b/tests/test_my_tado.py
@@ -30,6 +30,7 @@ class TadoTestCase(unittest.TestCase):
         self.http = Http()
         self.tado_client = Tado(self.http)
 
+
     def test_home_set_to_manual_mode(
         self,
     ):
@@ -95,25 +96,25 @@ class TadoTestCase(unittest.TestCase):
             assert self.tado_client._http.request.called
             assert running_times["lastUpdated"] == "2023-08-05T19:50:21Z"
             assert running_times["runningTimes"][0]["zones"][0]["id"] == 1
-            
+
     def get_eiq_consumption_overview(self):
             """Test the get_eiq_consumption_overview method."""
-            
+
             with mock.patch(
                 "PyTado.http.Http.request",
                 return_value=json.loads(common.load_fixture("consumption_overview.json")),
             ):
                 #consumption = self.tado_client.get_eiq_consumption_overview("2024", "03", "HUN")
                 consumption = self.tado_client.get_eiq_consumption_overview("2024-03")
-            
+
                 # Verify API call was made
                 assert self.tado_client._http.request.called
-            
+
                 # Verify summary data
                 assert consumption["summary"]["consumption"] == 10.575
                 assert consumption["summary"]["unit"] == "m3"
                 assert consumption["summary"]["tariff"]["unitPriceInCents"] == 9.18
-            
+
                 # Verify monthly data
                 monthly = consumption["graphConsumption"]["monthlyAggregation"][
                     "requestedMonth"
@@ -122,25 +123,24 @@ class TadoTestCase(unittest.TestCase):
                 assert monthly["endDate"] == "2025-04-10"
                 assert monthly["totalConsumption"] == 10.575
                 assert monthly["totalCostInCents"] == 1024.18
-            
+
                 # Verify consumption comparison
                 comparison = consumption["consumptionComparison"]["consumption"]
                 assert comparison["comparedToMonthBefore"]["trend"] == "DECREASE"
                 assert comparison["comparedToMonthBefore"]["percentage"] == 65
                 assert comparison["comparedToYearBefore"]["trend"] == "INCREASE"
                 assert comparison["comparedToYearBefore"]["percentage"] == 71
-            
+
                 # Verify room breakdown
                 rooms = consumption["roomBreakdown"]["requestedMonth"]["perRoom"]
                 assert len(rooms) == 7  # Verify total number of rooms
                 assert rooms[0]["name"] == "Schlafzimmer"
                 assert rooms[0]["consumption"] == 4.102
                 assert rooms[0]["costInCents"] == 397.27
-            
+
                 # Verify heating insights
                 insights = consumption["heatingInsights"]
                 assert insights["heatingHours"]["trend"] == "DECREASE"
                 assert insights["heatingHours"]["diff"] == 181
                 assert insights["outsideTemperature"]["diff"] == 1
                 assert insights["awayHours"]["diff"] == 37
-                


### PR DESCRIPTION
## Description
Hi, tado-engineer here.

This PR sets the user-agent header to PyTado/PyTado-version (e.g. `PyTado/0.19.2`) by default and allows users of this lib (e.g. Home Assistant) to supply a custom value.

This allows the maintainers of the tado servers to identify where requests are coming from and allows for better communication to resolve issues.

---

## Related Issues

---

## Type of Changes
Mark the type of changes included in this pull request:

- [ ] Bugfix
- [x] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Other (please specify):

---

## Checklist
- [ ] I have tested the changes locally and they work as expected.
- [ ] I have added/updated necessary documentation (if applicable).
- [ ] I have followed the code style and guidelines of the project.
- [ ] I have searched for and linked any related issues.

---

## Additional Notes
Add any additional comments, screenshots, or context for the reviewer(s).

---

Thank you for your contribution to PyTado! 🎉
