### PR TITLE
Fix/add successresult fallback http204

### DIFF
--- a/PyTado/http.py
+++ b/PyTado/http.py
@@ -318,8 +318,11 @@ class Http:
             raise TadoException(e) from e
 
         if response.text == "":
-            # HTTP 204 No Content typically means success
             if response.status_code == 204:
+                # Tado changed some (all?) APIs from HTTP 200 to HTTP 204.
+                # Make sure that PyTado returns {"success": True} if Tado returns HTTP 204
+                # to ensure that the interface of this library is not changed. Can be removed
+                # on the next breaking release.
                 return {"success": True}
             return {}
 


### PR DESCRIPTION
## Description
Tado changed some (all?) APIs from HTTP 200 to HTTP 204.

**Example:**
Example API response mytado:
PUT  https://my.tado.com/api/v2/homes/123456/zones/1/openWindowDetection
Payload: (as usual)
Response: HTTP 204

Example API response hops:
PUT https://hops.tado.com/homes/1234567/settings/owd/rooms/1
Payload: (as usual)
Response: HTTP 204

---

## Solution
As I'm not able to verify that indeed all APIs were changed by Tado, this PR supports both:
* HTTP 200 with `{"success": true}`
* HTTP 204 (No Content)

To ensure that users of PyTado depending on the `success: True` feedback do not need to change, that response is returned instead of No Content. Can be removed/refactored in the next breaking API change of PyTado.

---

## Related Issues
- Closes #264

---

## Type of Changes
Mark the type of changes included in this pull request:

- [x] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Other (please specify):

---

## Checklist
- [x] I have tested the changes locally and they work as expected.
- [ ] I have added/updated necessary documentation (if applicable).
- [x] I have followed the code style and guidelines of the project.
- [x] I have searched for and linked any related issues.

