### PR TITLE
Support homeId in me response

### DIFF
--- a/PyTado/http.py
+++ b/PyTado/http.py
@@ -648,9 +648,14 @@ class Http:
         if not isinstance(response, dict):
             raise TadoException("Unexpected response type")
 
-        homes_ = response["homes"]
+        homes_ = response.get("homes")
+        if isinstance(homes_, list) and homes_:
+            return int(homes_[0]["id"])
 
-        return int(homes_[0]["id"])
+        if home_id := response.get("homeId"):
+            return int(home_id)
+
+        raise TadoException("No home id found in response")
 
     def _check_x_line_generation(self) -> bool:
         # get home info

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -74,6 +74,22 @@ class TestHttp(unittest.TestCase):
         self.assertEqual(instance.is_x_line, False)
 
     @responses.activate
+    def test_login_successful_with_home_id_response(self):
+        """Test that login accepts a me response with homeId."""
+        responses.replace(
+            responses.GET,
+            "https://my.tado.com/api/v2/me",
+            json={"homeId": 1234},
+            status=200,
+        )
+
+        instance = Http(debug=True)
+        instance.device_activation()
+
+        self.assertEqual(instance._id, 1234)
+        self.assertEqual(instance.is_x_line, False)
+
+    @responses.activate
     def test_login_failed(self):
         """Test that login fails with appropriate exceptions."""
         responses.replace(


### PR DESCRIPTION
Some Tado accounts now return a `homeId` field from the `me` endpoint instead of a `homes` array. In that case device activation fails while `_get_id` indexes `response["homes"]`, which blocks Home Assistant's Tado config flow.

This keeps the existing `homes[0].id` path and adds a `homeId` fallback before raising a clear `TadoException` for unexpected responses.

Related Home Assistant issue: home-assistant/core#165689

Validation:
- `python -m pytest tests\test_http.py -q`
- `python -m pytest -q`
- `python -m ruff check PyTado\http.py --line-length=100`
- `python -m flake8 PyTado\http.py --max-line-length=100`
- `python -m black --check PyTado\http.py tests\test_http.py`
- `python -m bandit -c pyproject.toml PyTado\http.py`

Note: `python -m mypy PyTado tests` still reports existing repository-wide typing issues, including missing requests stubs and unannotated test functions; the new code path did not add errors in `PyTado/http.py`.