### PR TITLE
next_time_block can be None in a RoomState

### DIFF
--- a/PyTado/models/line_x/room.py
+++ b/PyTado/models/line_x/room.py
@@ -84,7 +84,7 @@ class RoomState(Base):
     connection: Connection
     open_window: XOpenWindow | None
     next_schedule_change: NextScheduleChange | None
-    next_time_block: NextTimeBlock
+    next_time_block: NextTimeBlock | None
     balance_control: str | None = None
     manual_control_termination: ManualControlTermination | None = None
     boost_mode: ManualControlTermination | None = None


### PR DESCRIPTION
## Description
next_time_block can be null in a `RoomState` response, so it should be able to be set to None like similar attributes inside `RoomState` model

---

## Related Issues
None

## Type of Changes
Mark the type of changes included in this pull request:

- [X] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Other (please specify):

---

## Checklist
- [X] I have tested the changes locally and they work as expected.
- [ ] I have added/updated necessary documentation (if applicable).
- [X] I have followed the code style and guidelines of the project.
- [X] I have searched for and linked any related issues.

---

